### PR TITLE
Add binding expression resolution to various bindings

### DIFF
--- a/src/DaprExtension/Bindings/DaprPublishAttribute.cs
+++ b/src/DaprExtension/Bindings/DaprPublishAttribute.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr
         /// <summary>
         /// Gets or sets the name of the topic to publish to.
         /// </summary>
+        [AutoResolve]
         public string? Topic { get; set; }
     }
 }

--- a/src/DaprExtension/Triggers/DaprBindingTriggerAttribute.cs
+++ b/src/DaprExtension/Triggers/DaprBindingTriggerAttribute.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr
         /// <remarks>
         /// If not specified, the name of the function is used as the trigger name.
         /// </remarks>
+        [AutoResolve]
         public string? BindingName { get; set; }
     }
 }

--- a/src/DaprExtension/Triggers/DaprTopicTriggerAttribute.cs
+++ b/src/DaprExtension/Triggers/DaprTopicTriggerAttribute.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr
         /// <summary>
         /// Gets or sets the name of the topic.
         /// </summary>
+        [AutoResolve]
         public string? Topic { get; set; }
     }
 }


### PR DESCRIPTION
Some bindings were missing the [AutoResolver] attribute, meaning they
could not be used with binding expressions.

This PR adds them to the fields missing them.