### PR TITLE
Downgrading System.Text.Json verson to 6.0.7 as 7.* version doesn't w…

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Dapr/Microsoft.Azure.WebJobs.Extensions.Dapr.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Dapr/Microsoft.Azure.WebJobs.Extensions.Dapr.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.2.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.36" />
-    <PackageReference Include="System.Text.Json" Version="7.0.2" />
+    <PackageReference Include="System.Text.Json" Version="6.0.7" />
   </ItemGroup>
 
   <!-- 3rd party dependencies -->


### PR DESCRIPTION
Downgrading System.Text.Json verson to 6.0.7 as 7.* version doesn't work with azure functions rigth now.