### PR TITLE
bugfix: Avoid deserialization DaprPubSubEvent

### DIFF
--- a/samples/javascript-azurefunction/local.settings.json
+++ b/samples/javascript-azurefunction/local.settings.json
@@ -4,6 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "StateStoreName": "statestore", // should be same as metatdata.name in components/statestore.yaml
-    "KafkaBindingName": "sample-topic" // should be same as metatdata.name in components/kafka_binding.yaml
+    "KafkaBindingName": "sample-topic", // should be same as metatdata.name in components/kafka_binding.yaml
+    "AzureWebJobsSecretStorageType": "files"
   }
 }

--- a/src/Microsoft.Azure.Functions.Extensions.Dapr.Core/InvokeMethodParameters.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Dapr.Core/InvokeMethodParameters.cs
@@ -5,8 +5,6 @@
 
 namespace Microsoft.Azure.Functions.Extensions.Dapr.Core
 {
-    using System;
-
     /// <summary>
     /// Parameters for Dapr invoke-method operations.
     /// </summary>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Dapr/DaprExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Dapr/DaprExtensionConfigProvider.cs
@@ -151,25 +151,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr
         {
             if (!json.TryGetProperty("payload", out JsonElement payload))
             {
-                throw new ArgumentException("A 'payload' parameter is required for outbound pub/sub operations.", nameof(json));
+                throw new ArgumentException($"A '{nameof(json).ToLowerInvariant()}' parameter is required for outbound pub/sub operations.");
             }
 
             object? payloadObject = payload.Deserialize<object>();
             if (payloadObject == null)
             {
-                throw new ArgumentException($"A '{nameof(payloadObject).ToLowerInvariant()}' parameter is required for outbound pub/sub operations.", nameof(json));
+                throw new ArgumentException($"Could not deserialize '{nameof(payloadObject).ToLowerInvariant()}' parameter for outbound pub/sub operations.");
             }
 
             DaprPubSubEvent event_ = new DaprPubSubEvent(payloadObject);
 
-            if (json.TryGetProperty("topic", out JsonElement topic))
-            {
-                event_.Topic = topic.GetString();
-            }
-
             if (json.TryGetProperty("pubsubname", out JsonElement pubsubName))
             {
                 event_.PubSubName = pubsubName.GetString();
+            }
+
+            if (json.TryGetProperty("topic", out JsonElement topic))
+            {
+                event_.Topic = topic.GetString();
             }
 
             return event_;

--- a/src/Microsoft.Azure.WebJobs.Extensions.Dapr/DaprExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Dapr/DaprExtensionConfigProvider.cs
@@ -149,10 +149,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr
 
         static DaprPubSubEvent CreatePubSubEvent(JsonElement json)
         {
-            DaprPubSubEvent? event_ = JsonSerializer.Deserialize<DaprPubSubEvent>(json);
-            if (event_ == null)
+            if (!json.TryGetProperty("payload", out JsonElement payload))
             {
-                throw new ArgumentException($"A '{nameof(event_.Payload).ToLowerInvariant()}' parameter is required for outbound pub/sub operations.", nameof(json));
+                throw new ArgumentException("A 'payload' parameter is required for outbound pub/sub operations.", nameof(json));
+            }
+
+            object? payloadObject = payload.Deserialize<object>();
+            if (payloadObject == null)
+            {
+                throw new ArgumentException($"A '{nameof(payloadObject).ToLowerInvariant()}' parameter is required for outbound pub/sub operations.", nameof(json));
+            }
+
+            DaprPubSubEvent event_ = new DaprPubSubEvent(payloadObject);
+
+            if (json.TryGetProperty("topic", out JsonElement topic))
+            {
+                event_.Topic = topic.GetString();
+            }
+
+            if (json.TryGetProperty("pubsubname", out JsonElement pubsubName))
+            {
+                event_.PubSubName = pubsubName.GetString();
             }
 
             return event_;


### PR DESCRIPTION
When PubSubName and Topic are provided as attributes instead of parameters, it fails with the following error:

<pre>
System.Private.CoreLib: Exception while executing function: Functions.CreateNewOrder. System.Text.Json: Each parameter in the deserialization constructor on type 'Microsoft.Azure.Functions.Extensions.Dapr.Core.DaprPubSubEvent' must bind to an object property or field on deserialization. Each parameter name must match with a property or field on the object. The match can be case-insensitive.
</pre>

It is because the `JsonSerializer` tries to deserialize PubSub event and expects all the fields. Like other classes, this should also follow the model where we create a class from only what's required (payload, in this case), and then optionally add PubSubName and Topic.