### PR TITLE
Handling state management key not found

### DIFF
--- a/samples/dotnet-azurefunction/DaprStateInputBindingUserDefinedType.cs
+++ b/samples/dotnet-azurefunction/DaprStateInputBindingUserDefinedType.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License.
 // ------------------------------------------------------------
 
-namespace dotnet_isolated_azurefunction
+namespace dotnet_azurefunction
 {
     using System.Text.Json;
     using Microsoft.Azure.WebJobs;

--- a/samples/dotnet-azurefunction/DaprStateOutputBindingUserDefinedType.cs
+++ b/samples/dotnet-azurefunction/DaprStateOutputBindingUserDefinedType.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License.
 // ------------------------------------------------------------
 
-namespace dotnet_isolated_azurefunction
+namespace dotnet_azurefunction
 {
     using System.Text.Json;
     using System.Text.Json.Serialization;

--- a/src/Microsoft.Azure.WebJobs.Extensions.Dapr/Utils/ErrorCodes.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Dapr/Utils/ErrorCodes.cs
@@ -38,5 +38,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr.Utils
         /// Unknown Error.
         /// </summary>
         public const string ErrUnknown = "ERR_UNKNOWN";
+
+        /// <summary>
+        /// No Content.
+        /// </summary>
+        public const string ErrNoContent = "ERR_NO_CONTENT";
     }
 }


### PR DESCRIPTION
This PR adds state key not found error message to let user know that key they are looking for in state store is not found.

This close #93