### PR TITLE
Update build pipeline, add CODEOWNERS and development docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,27 @@ jobs:
         run: dotnet build --configuration ${{ env.CONFIGURATION }} --configfile nuget.config
       - name: Run Unit Tests - ${{ env.CONFIGURATION }}
         run: dotnet test --configuration ${{ env.CONFIGURATION }} --no-build --verbosity normal
+      # The docker image is not pushed for pull requests,
+      # but the image is built to ensure that the Dockerfile and the sample app are valid.
+      - name: Set a sample app registry when it is a pull request
+        if: github.event_name == 'pull_request'
+        run: |
+          OWNER_NAME="${GITHUB_REPOSITORY%%/*}"
+          OWNER_NAME="${OWNER_NAME,,}" # convert to lowercase
+          echo "Setting sample app registry to ghcr.io/${OWNER_NAME}"
+          echo "APP_REGISTRY=ghcr.io/${OWNER_NAME}" >> $GITHUB_ENV
+      - name: Build samples docker images
+        run: |
+          echo building docker image for ${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}
+          docker build -f samples/dotnet-azurefunction/Dockerfile -t ${{ env.APP_REGISTRY }}/${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}:${{ env.REL_VERSION }} .
+      - name: Push samples docker images
+        if: github.event_name != 'pull_request'
+        run: |
+          echo performing docker login
+          docker login -u ${{ secrets.DOCKER_REGISTRY_ID }} -p ${{ secrets.DOCKER_REGISTRY_PASS }}
+          echo pushing docker image for ${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}
+          echo image with tag ${{ env.APP_REGISTRY }}/${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}:${{ env.REL_VERSION }} will be pushed
+          docker push ${{ env.APP_REGISTRY }}/${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}:${{ env.REL_VERSION }}
       - name: Generate NuGet Packages - ${{ env.CONFIGURATION }}
         if: startswith(github.ref, 'refs/tags/v')
         run: dotnet pack --configuration ${{ env.CONFIGURATION }} -p:PackageVersion=${REL_VERSION}
@@ -51,7 +72,7 @@ jobs:
         with:
           name: release_drop
           path: ${{ env.NUPKG_OUTDIR }}
-      - name: Publish binaries to github for tags
+      - name: Create a GitHub Release
         if: startswith(github.ref, 'refs/tags/v')
         run: |
           RELEASE_ARTIFACT=(${NUPKG_OUTDIR}/*)
@@ -75,24 +96,3 @@ jobs:
           export AZCOPY_SPA_CLIENT_SECRET=${{ secrets.AZCOPY_SPA_CLIENT_SECRET }}
           ./azcopy login --service-principal --application-id ${{ secrets.AZCOPY_SPA_APPLICATION_ID }}
           ./azcopy copy "${{ env.NUPKG_OUTDIR }}/*" "https://azuresdkpartnerdrops.blob.core.windows.net/drops/azure-functions-dapr-extension/dotnet/${{ env.REL_VERSION }}/"
-      # The docker image is not pushed for pull requests,
-      # but the image is built to ensure that the Dockerfile and the sample app are valid.
-      - name: Set a sample app registry when it is a pull request
-        if: github.event_name == 'pull_request'
-        run: |
-          OWNER_NAME="${GITHUB_REPOSITORY%%/*}"
-          OWNER_NAME="${OWNER_NAME,,}" # convert to lowercase
-          echo "Setting sample app registry to ghcr.io/${OWNER_NAME}"
-          echo "APP_REGISTRY=ghcr.io/${OWNER_NAME}" >> $GITHUB_ENV
-      - name: Build samples docker images
-        run: |
-          echo building docker image for ${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}
-          docker build -f samples/dotnet-azurefunction/Dockerfile -t ${{ env.APP_REGISTRY }}/${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}:${{ env.REL_VERSION }} .
-      - name: Push samples docker images
-        if: github.event_name != 'pull_request'
-        run: |
-          echo performing docker login
-          docker login -u ${{ secrets.DOCKER_REGISTRY_ID }} -p ${{ secrets.DOCKER_REGISTRY_PASS }}
-          echo pushing docker image for ${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}
-          echo image with tag ${{ env.APP_REGISTRY }}/${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}:${{ env.REL_VERSION }} will be pushed
-          docker push ${{ env.APP_REGISTRY }}/${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}:${{ env.REL_VERSION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,11 +54,11 @@ jobs:
       - name: Publish binaries to github for tags
         # if: startswith(github.ref, 'refs/tags/v')
         run: |
-          RELEASE_ARTIFACT=(${{ env.NUPKG_OUTDIR }}/*)
+          RELEASE_ARTIFACT=(${NUPKG_OUTDIR}/*)
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           echo "Uploading Nuget packages to GitHub Release"
 
-          gh release create "v${REL_VERSION}" "${env.NUPKG_OUTDIR}/*" \
+          gh release create "v${REL_VERSION}" ${RELEASE_ARTIFACT[*]} \
           --repo "${GITHUB_REPOSITORY}" \
           --title "Azure Functions Dapr Extension v${REL_VERSION}" \
           --notes "Release Azure Functions Dapr Extension v${REL_VERSION}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Run Unit Tests - ${{ env.CONFIGURATION }}
         run: dotnet test --configuration ${{ env.CONFIGURATION }} --no-build --verbosity normal
       - name: Generate NuGet Packages - ${{ env.CONFIGURATION }}
-        if: startswith(github.ref, 'refs/tags/v')
+        # if: startswith(github.ref, 'refs/tags/v')
         run: dotnet pack --configuration ${{ env.CONFIGURATION }} -p:PackageVersion=${REL_VERSION}
         # Since we create local development nuget packages, we need to clean them up.
       - name: Clean up development Nuget packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         # if: startswith(github.ref, 'refs/tags/v')
         run: |
           RELEASE_ARTIFACT=(${NUPKG_OUTDIR}/*)
-          export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          export GITHUB_TOKEN=${{ secrets.RELEASE_TOKEN }}
           echo "Uploading Nuget packages to GitHub Release"
 
           gh release create "v${REL_VERSION}" ${RELEASE_ARTIFACT[*]} \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,11 +26,10 @@ jobs:
       DEV_VERSION_SUFFIX: 99.99.99
       DOTNET_SAMPLE_APP_IMAGE_NAME: dotnet-azurefunction
       NUPKG_OUTDIR: bin/Release/nugets
-      REL_VERSION: "0.14.0-preview01"
     steps:
       - uses: actions/checkout@v2
-      # - name: Parse release version
-      #   run: python ./.github/scripts/get_release_version.py
+      - name: Parse release version
+        run: python ./.github/scripts/get_release_version.py
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
         with:
@@ -40,20 +39,20 @@ jobs:
       - name: Run Unit Tests - ${{ env.CONFIGURATION }}
         run: dotnet test --configuration ${{ env.CONFIGURATION }} --no-build --verbosity normal
       - name: Generate NuGet Packages - ${{ env.CONFIGURATION }}
-        # if: startswith(github.ref, 'refs/tags/v')
+        if: startswith(github.ref, 'refs/tags/v')
         run: dotnet pack --configuration ${{ env.CONFIGURATION }} -p:PackageVersion=${REL_VERSION}
         # Since we create local development nuget packages, we need to clean them up.
       - name: Clean up development Nuget packages
-        # if: startswith(github.ref, 'refs/tags/v')
+        if: startswith(github.ref, 'refs/tags/v')
         run: rm -rf $NUPKG_OUTDIR/*${DEV_VERSION_SUFFIX}.*{nupkg,snupkg}
       - name: Upload artifacts
         uses: actions/upload-artifact@master
-        # if: startswith(github.ref, 'refs/tags/v')
+        if: startswith(github.ref, 'refs/tags/v')
         with:
           name: release_drop
           path: ${{ env.NUPKG_OUTDIR }}
       - name: Publish binaries to github for tags
-        # if: startswith(github.ref, 'refs/tags/v')
+        if: startswith(github.ref, 'refs/tags/v')
         run: |
           RELEASE_ARTIFACT=(${NUPKG_OUTDIR}/*)
           export GITHUB_TOKEN=${{ secrets.RELEASE_TOKEN }}
@@ -63,10 +62,19 @@ jobs:
           --repo "${GITHUB_REPOSITORY}" \
           --title "Azure Functions Dapr Extension v${REL_VERSION}" \
           --notes "Release Azure Functions Dapr Extension v${REL_VERSION}"
-      # - name: Publish nuget packages to nuget.org for tags
-      #   if: startswith(github.ref, 'refs/tags/v') && !(endsWith(github.ref, '-rc') || endsWith(github.ref, '-dev') || endsWith(github.ref, '-prerelease'))
-      #   run: |
-      #     dotnet nuget push "${{ env.NUPKG_OUTDIR }}/*.nupkg" --skip-duplicate --api-key ${{ secrets.NUGETORG_DAPR_API_KEY }} --source https://api.nuget.org/v3/index.json
+      - name: Upload NuGet packages to Azure blob storage
+        if: |
+          startsWith(github.ref, 'refs/tags/v') &&
+          !(endsWith(github.ref, '-rc') || endsWith(github.ref, '-dev') || endsWith(github.ref, '-prerelease')) &&
+          github.repository == 'Azure/azure-functions-dapr-extension'
+        run: |
+          # Install azcopy
+          wget -O azcopy_v10.tar.gz https://aka.ms/downloadazcopy-v10-linux && tar -xf azcopy_v10.tar.gz --strip-components=1
+
+          # Upload nuget packages to Azure blob storage
+          set AZCOPY_SPA_CLIENT_SECRET=${{ secrets.AZCOPY_SPA_CLIENT_SECRET }}
+          ./azcopy login --service-principal --application-id ${{ secrets.AZCOPY_SPA_APPLICATION_ID }}
+          ./azcopy copy "${{ env.NUPKG_OUTDIR }}/*" "https://azuresdkpartnerdrops.blob.core.windows.net/drops/azure-functions-dapr-extension/dotnet/${{ env.REL_VERSION }}/"
       # The docker image is not pushed for pull requests,
       # but the image is built to ensure that the Dockerfile and the sample app are valid.
       - name: Set a sample app registry when it is a pull request
@@ -80,11 +88,11 @@ jobs:
         run: |
           echo building docker image for ${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}
           docker build -f samples/dotnet-azurefunction/Dockerfile -t ${{ env.APP_REGISTRY }}/${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}:${{ env.REL_VERSION }} .
-      # - name: Push samples docker images
-      #   if: github.event_name != 'pull_request'
-      #   run: |
-      #     echo performing docker login
-      #     docker login -u ${{ secrets.DOCKER_REGISTRY_ID }} -p ${{ secrets.DOCKER_REGISTRY_PASS }}
-      #     echo pushing docker image for ${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}
-      #     echo image with tag ${{ env.APP_REGISTRY }}/${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}:${{ env.REL_VERSION }} will be pushed
-      #     docker push ${{ env.APP_REGISTRY }}/${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}:${{ env.REL_VERSION }}
+      - name: Push samples docker images
+        if: github.event_name != 'pull_request'
+        run: |
+          echo performing docker login
+          docker login -u ${{ secrets.DOCKER_REGISTRY_ID }} -p ${{ secrets.DOCKER_REGISTRY_PASS }}
+          echo pushing docker image for ${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}
+          echo image with tag ${{ env.APP_REGISTRY }}/${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}:${{ env.REL_VERSION }} will be pushed
+          docker push ${{ env.APP_REGISTRY }}/${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}:${{ env.REL_VERSION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,11 @@ jobs:
       DEV_VERSION_SUFFIX: 99.99.99
       DOTNET_SAMPLE_APP_IMAGE_NAME: dotnet-azurefunction
       NUPKG_OUTDIR: bin/Release/nugets
+      REL_VERSION: "0.14.0-preview01"
     steps:
       - uses: actions/checkout@v2
-      - name: Parse release version
-        run: python ./.github/scripts/get_release_version.py
+      # - name: Parse release version
+      #   run: python ./.github/scripts/get_release_version.py
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,15 +43,16 @@ jobs:
         run: dotnet pack --configuration ${{ env.CONFIGURATION }} -p:PackageVersion=${REL_VERSION}
         # Since we create local development nuget packages, we need to clean them up.
       - name: Clean up development Nuget packages
-        if: startswith(github.ref, 'refs/tags/v')
+        # if: startswith(github.ref, 'refs/tags/v')
         run: rm -rf ${{ env.NUPKG_OUTDIR }}/*${{ env.DEV_VERSION_SUFFIX }}*.nupkg
       - name: Upload artifacts
         uses: actions/upload-artifact@master
+        # if: startswith(github.ref, 'refs/tags/v')
         with:
           name: release_drop
           path: ${{ env.NUPKG_OUTDIR }}
       - name: Publish binaries to github for tags
-        if: startswith(github.ref, 'refs/tags/v')
+        # if: startswith(github.ref, 'refs/tags/v')
         run: |
           sudo npm install --silent --no-progress -g github-release-cli
 
@@ -71,10 +72,10 @@ jobs:
             --tag "v${REL_VERSION}" \
             --name "Dapr Azure Functions Extension v${REL_VERSION}" \
             ${RELEASE_ARTIFACT[*]}
-      - name: Publish nuget packages to nuget.org for tags
-        if: startswith(github.ref, 'refs/tags/v') && !(endsWith(github.ref, '-rc') || endsWith(github.ref, '-dev') || endsWith(github.ref, '-prerelease'))
-        run: |
-          dotnet nuget push "${{ env.NUPKG_OUTDIR }}/*.nupkg" --skip-duplicate --api-key ${{ secrets.NUGETORG_DAPR_API_KEY }} --source https://api.nuget.org/v3/index.json
+      # - name: Publish nuget packages to nuget.org for tags
+      #   if: startswith(github.ref, 'refs/tags/v') && !(endsWith(github.ref, '-rc') || endsWith(github.ref, '-dev') || endsWith(github.ref, '-prerelease'))
+      #   run: |
+      #     dotnet nuget push "${{ env.NUPKG_OUTDIR }}/*.nupkg" --skip-duplicate --api-key ${{ secrets.NUGETORG_DAPR_API_KEY }} --source https://api.nuget.org/v3/index.json
       # The docker image is not pushed for pull requests,
       # but the image is built to ensure that the Dockerfile and the sample app are valid.
       - name: Set a sample app registry when it is a pull request

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         if: startswith(github.ref, 'refs/tags/v')
         run: |
           RELEASE_ARTIFACT=(${NUPKG_OUTDIR}/*)
-          export GITHUB_TOKEN=${{ secrets.RELEASE_TOKEN }}
+          export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           echo "Uploading Nuget packages to GitHub Release"
 
           gh release create "v${REL_VERSION}" ${RELEASE_ARTIFACT[*]} \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,8 @@ jobs:
       DEV_VERSION_SUFFIX: 99.99.99
       DOTNET_SAMPLE_APP_IMAGE_NAME: dotnet-azurefunction
       NUPKG_OUTDIR: bin/Release/nugets
+      # TODO: Temporary
+      REL_VERSION: "0.14.0-preview01"
     steps:
       - uses: actions/checkout@v2
       - name: Parse release version
@@ -44,7 +46,7 @@ jobs:
         # Since we create local development nuget packages, we need to clean them up.
       - name: Clean up development Nuget packages
         # if: startswith(github.ref, 'refs/tags/v')
-        run: rm -rf ${{ env.NUPKG_OUTDIR }}/*${{ env.DEV_VERSION_SUFFIX }}*.nupkg
+        run: rm -rf $NUPKG_OUTDIR/*${DEV_VERSION_SUFFIX}.*{nupkg,snupkg}
       - name: Upload artifacts
         uses: actions/upload-artifact@master
         # if: startswith(github.ref, 'refs/tags/v')
@@ -79,11 +81,11 @@ jobs:
         run: |
           echo building docker image for ${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}
           docker build -f samples/dotnet-azurefunction/Dockerfile -t ${{ env.APP_REGISTRY }}/${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}:${{ env.REL_VERSION }} .
-      - name: Push samples docker images
-        if: github.event_name != 'pull_request'
-        run: |
-          echo performing docker login 
-          docker login -u ${{ secrets.DOCKER_REGISTRY_ID }} -p ${{ secrets.DOCKER_REGISTRY_PASS }}
-          echo pushing docker image for ${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}
-          echo image with tag ${{ env.APP_REGISTRY }}/${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}:${{ env.REL_VERSION }} will be pushed
-          docker push ${{ env.APP_REGISTRY }}/${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}:${{ env.REL_VERSION }}
+      # - name: Push samples docker images
+      #   if: github.event_name != 'pull_request'
+      #   run: |
+      #     echo performing docker login
+      #     docker login -u ${{ secrets.DOCKER_REGISTRY_ID }} -p ${{ secrets.DOCKER_REGISTRY_PASS }}
+      #     echo pushing docker image for ${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}
+      #     echo image with tag ${{ env.APP_REGISTRY }}/${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}:${{ env.REL_VERSION }} will be pushed
+      #     docker push ${{ env.APP_REGISTRY }}/${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}:${{ env.REL_VERSION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
           wget -O azcopy_v10.tar.gz https://aka.ms/downloadazcopy-v10-linux && tar -xf azcopy_v10.tar.gz --strip-components=1
 
           # Upload nuget packages to Azure blob storage
-          set AZCOPY_SPA_CLIENT_SECRET=${{ secrets.AZCOPY_SPA_CLIENT_SECRET }}
+          export AZCOPY_SPA_CLIENT_SECRET=${{ secrets.AZCOPY_SPA_CLIENT_SECRET }}
           ./azcopy login --service-principal --application-id ${{ secrets.AZCOPY_SPA_APPLICATION_ID }}
           ./azcopy copy "${{ env.NUPKG_OUTDIR }}/*" "https://azuresdkpartnerdrops.blob.core.windows.net/drops/azure-functions-dapr-extension/dotnet/${{ env.REL_VERSION }}/"
       # The docker image is not pushed for pull requests,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,6 @@ jobs:
       DEV_VERSION_SUFFIX: 99.99.99
       DOTNET_SAMPLE_APP_IMAGE_NAME: dotnet-azurefunction
       NUPKG_OUTDIR: bin/Release/nugets
-      # TODO: Temporary
-      REL_VERSION: "0.14.0-preview01"
     steps:
       - uses: actions/checkout@v2
       - name: Parse release version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,24 +54,14 @@ jobs:
       - name: Publish binaries to github for tags
         # if: startswith(github.ref, 'refs/tags/v')
         run: |
-          sudo npm install --silent --no-progress -g github-release-cli
-
-          # Parse repository to get owner and repo names
-          OWNER_NAME="${GITHUB_REPOSITORY%%/*}"
-          REPO_NAME="${GITHUB_REPOSITORY#*/}"
-
-          # Get the list of files
           RELEASE_ARTIFACT=(${{ env.NUPKG_OUTDIR }}/*)
-
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           echo "Uploading Nuget packages to GitHub Release"
-          github-release upload \
-            --owner $OWNER_NAME \
-            --repo $REPO_NAME \
-            --body "Release dapr azure functions extension v${REL_VERSION}" \
-            --tag "v${REL_VERSION}" \
-            --name "Dapr Azure Functions Extension v${REL_VERSION}" \
-            ${RELEASE_ARTIFACT[*]}
+
+          gh release create "v${REL_VERSION}" "${env.NUPKG_OUTDIR}/*" \
+          --repo "${GITHUB_REPOSITORY}" \
+          --title "Azure Functions Dapr Extension v${REL_VERSION}" \
+          --notes "Release Azure Functions Dapr Extension v${REL_VERSION}"
       # - name: Publish nuget packages to nuget.org for tags
       #   if: startswith(github.ref, 'refs/tags/v') && !(endsWith(github.ref, '-rc') || endsWith(github.ref, '-dev') || endsWith(github.ref, '-prerelease'))
       #   run: |

--- a/.github/workflows/get_release_version.py
+++ b/.github/workflows/get_release_version.py
@@ -12,10 +12,6 @@ import sys
 gitRef = os.getenv("GITHUB_REF")
 tagRefPrefix = "refs/tags/v"
 
-# TEMP
-print("##[set-env name=REL_VERSION;]{}".format("0.14.0-preview01"))
-sys.exit(0)
-
 # Is this an edge build?
 if gitRef is None or not gitRef.startswith(tagRefPrefix):
     print("##[set-env name=REL_VERSION;]edge")

--- a/.github/workflows/get_release_version.py
+++ b/.github/workflows/get_release_version.py
@@ -26,4 +26,6 @@ if gitRef.find("-preview") > 0:
     print("##[set-env name=PREVIEW_RELEASE;]true")
     print("Preview build from {}...".format(gitRef))
 
-print("##[set-env name=REL_VERSION;]{}".format(releaseVersion))
+# TEMPORARY: Set release version to 0.14.0-preview01
+# print("##[set-env name=REL_VERSION;]{}".format(releaseVersion))
+print("##[set-env name=REL_VERSION;]{}".format("0.14.0-preview01"))

--- a/.github/workflows/get_release_version.py
+++ b/.github/workflows/get_release_version.py
@@ -12,6 +12,10 @@ import sys
 gitRef = os.getenv("GITHUB_REF")
 tagRefPrefix = "refs/tags/v"
 
+# TEMP
+print("##[set-env name=REL_VERSION;]{}".format("0.14.0-preview01"))
+sys.exit(0)
+
 # Is this an edge build?
 if gitRef is None or not gitRef.startswith(tagRefPrefix):
     print("##[set-env name=REL_VERSION;]edge")
@@ -26,6 +30,4 @@ if gitRef.find("-preview") > 0:
     print("##[set-env name=PREVIEW_RELEASE;]true")
     print("Preview build from {}...".format(gitRef))
 
-# TEMPORARY: Set release version to 0.14.0-preview01
-# print("##[set-env name=REL_VERSION;]{}".format(releaseVersion))
-print("##[set-env name=REL_VERSION;]{}".format("0.14.0-preview01"))
+print("##[set-env name=REL_VERSION;]{}".format(releaseVersion))

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# These owners are the maintainers of this repo
+*       @Azure/maintainers-azure-functions-dapr-extension

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,0 +1,5 @@
+# Development
+
+* [Development](./development.md) - How to setup local development environment and build/test Azure Functions Dapr Extension.
+* [Release Process](./release-process.md) - How to release Azure Functions Dapr Extension.
+* [Setup Continuous Integration](./setup-ci.md) - How to setup GitHub Actions for Azure Functions Dapr Extension.

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -1,0 +1,13 @@
+# Setup Local Development
+
+This document is a TODO.
+
+## Prerequisites
+
+## Clone the repository
+
+## Build the project
+
+## Run tests
+
+## Debugging

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -1,0 +1,5 @@
+# Release Process
+
+This document describes the release process for Azure Functions Dapr Extension.
+
+TODO: Add more details.

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -2,4 +2,18 @@
 
 This document describes the release process for Azure Functions Dapr Extension.
 
-TODO: Add more details.
+## Trigger a release
+
+1. Create a new branch from `master` branch in the format of `release-<major>.<minor>` (e.g. `release-0.14`).
+2. Add a tag and push it.
+```bash
+$ git tag "v0.14.0-preview01" -m "v0.14.0-preview01"
+$ git push --tags
+```
+3. CI will create a new release in GitHub, push the NuGet packages to Azure blob storage, and upload the sample image to Docker registry.
+4. [MICROSOFT PROCESS] Upload the NuGet packages to NuGet.org using the Azure DevOps pipeline.
+5. Edit the release notes if necessary.
+6. Test and validate the functionalities with the specific version
+7. If there are regressions and bugs, fix them in `release-*` branch and merge back to master
+8. Create new tags (with suffix -preview02, -preview03, etc.) and push them to trigger CI to create new releases
+9. Repeat from 6 to 8 until all bugs are fixed

--- a/docs/development/setup-ci.md
+++ b/docs/development/setup-ci.md
@@ -19,7 +19,7 @@ A GitHub account.
 | DOCKER_REGISTRY_ID | Username for Docker registry, required for uploading sample image|
 | DOCKER_REGISTRY_PASS | Password for Docker registry, required for uploading sample image|
 | DOCKER_REGISTRY | URL to Docker registry, required for uploading sample image|
-| GITHUB_TOKEN | Token to publish binaries to GitHub during release |
+| GITHUB_TOKEN | Token to publish binaries to GitHub during release (*automatically created by GitHub*) |
 | NUGETORG_DAPR_API_KEY | API key to publish package to NuGet |
 
 4. Go to `Settings` -> `Actions` -> `General` and make sure to allow running GitHub Actions.

--- a/docs/development/setup-ci.md
+++ b/docs/development/setup-ci.md
@@ -18,9 +18,12 @@ A GitHub account.
 |--|--|
 | DOCKER_REGISTRY_ID | Username for Docker registry, required for uploading sample image|
 | DOCKER_REGISTRY_PASS | Password for Docker registry, required for uploading sample image|
-| DOCKER_REGISTRY | URL to Docker registry, required for uploading sample image|
-| RELEASE_TOKEN | Token to publish binaries to GitHub during release (TODO: add permissions) |
-| NUGETORG_DAPR_API_KEY | API key to publish package to NuGet |
+| DOCKER_REGISTRY | URL to Docker registry, required for uploading sample image |
+| RELEASE_TOKEN | Token to publish binaries to GitHub during release (minimum permissions: `repo`) |
+| AZCOPY_SPA_APPLICATION_ID | Service principal application ID for AzCopy, required for uploading NuGet packages |
+| AZCOPY_SPA_CLIENT_SECRET | Service principal client secret for AzCopy, required for uploading NuGet packages |
+
+Note, `AZCOPY_*` secrets should not be set for forks, as they are only required for uploading NuGet packages for official release. The step that requires these secrets will be skipped for forks.
 
 4. Go to `Settings` -> `Actions` -> `General` and make sure to allow running GitHub Actions.
 

--- a/docs/development/setup-ci.md
+++ b/docs/development/setup-ci.md
@@ -1,0 +1,27 @@
+# Setup Continuous Integration
+
+This repository uses GitHub Actions to automate the build and release. As long as you have a GitHub Account, you can set up your own private Actions in your own fork. This document helps you set up the continuous integration for Azure Functions Dapr Extension.
+
+## Prerequisites
+
+A GitHub account.
+
+## Setup
+
+1. Fork [Azure/azure-functions-dapr-extension](https://github.com/Azure/azure-functions-dapr-extension) to your GitHub account.
+2. Go to `Settings`-> `Secrets and variables` -> `Actions`.
+3. Add the required repository secrets.
+
+### Required repository secrets
+
+| Name | Description |
+|--|--|
+| DOCKER_REGISTRY_ID | Username for Docker registry, required for uploading sample image|
+| DOCKER_REGISTRY_PASS | Password for Docker registry, required for uploading sample image|
+| DOCKER_REGISTRY | URL to Docker registry, required for uploading sample image|
+| GITHUB_TOKEN | Token to publish binaries to GitHub during release |
+| NUGETORG_DAPR_API_KEY | API key to publish package to NuGet |
+
+4. Go to `Settings` -> `Actions` -> `General` and make sure to allow running GitHub Actions.
+
+

--- a/docs/development/setup-ci.md
+++ b/docs/development/setup-ci.md
@@ -19,7 +19,7 @@ A GitHub account.
 | DOCKER_REGISTRY_ID | Username for Docker registry, required for uploading sample image|
 | DOCKER_REGISTRY_PASS | Password for Docker registry, required for uploading sample image|
 | DOCKER_REGISTRY | URL to Docker registry, required for uploading sample image|
-| GITHUB_TOKEN | Token to publish binaries to GitHub during release (*automatically created by GitHub*) |
+| RELEASE_TOKEN | Token to publish binaries to GitHub during release (TODO: add permissions) |
 | NUGETORG_DAPR_API_KEY | API key to publish package to NuGet |
 
 4. Go to `Settings` -> `Actions` -> `General` and make sure to allow running GitHub Actions.

--- a/docs/development/setup-ci.md
+++ b/docs/development/setup-ci.md
@@ -19,11 +19,13 @@ A GitHub account.
 | DOCKER_REGISTRY_ID | Username for Docker registry, required for uploading sample image|
 | DOCKER_REGISTRY_PASS | Password for Docker registry, required for uploading sample image|
 | DOCKER_REGISTRY | URL to Docker registry, required for uploading sample image |
-| RELEASE_TOKEN | Token to publish binaries to GitHub during release (minimum permissions: `repo`) |
 | AZCOPY_SPA_APPLICATION_ID | Service principal application ID for AzCopy, required for uploading NuGet packages |
 | AZCOPY_SPA_CLIENT_SECRET | Service principal client secret for AzCopy, required for uploading NuGet packages |
+| GITHUB_TOKEN | GitHub token, required for creating release |
 
-Note, `AZCOPY_*` secrets should not be set for forks, as they are only required for uploading NuGet packages for official release. The step that requires these secrets will be skipped for forks.
+Notes
+- `GITHUB_TOKEN` is automatically set by GitHub Actions, so you don't need to set it manually.
+- `AZCOPY_*` secrets should not be set for forks, as they are only required for uploading NuGet packages for official release. The step that requires these secrets will be skipped for forks.
 
 4. Go to `Settings` -> `Actions` -> `General` and make sure to allow running GitHub Actions.
 

--- a/properties/common.props
+++ b/properties/common.props
@@ -30,10 +30,11 @@
   </PropertyGroup>
 
   <!-- Signing -->
-  <PropertyGroup>
+  <!-- Skip signing here and rely on the Azure SDK CI to sign the assembly -->
+  <!-- <PropertyGroup>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)key.snk</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
+  </PropertyGroup> -->
 
   <!-- Enable sourcelink https://docs.microsoft.com/dotnet/standard/library-guidance/sourcelink -->
   <PropertyGroup>


### PR DESCRIPTION
Preparing for release
- Update build pipeline to push artifacts to blob storage
- Replace github-release-cli with official GH cli (closes #85)
- Skip signing the artifacts, Azure SDK pipeline takes care of it
- Add CODEOWNERS file 
- Add development documentation