### PR TITLE
Allow custom docker login registry in pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      APP_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+      APP_REGISTRY: ${{ secrets.DOCKER_REGISTRY_URL }}/${{ secrets.DOCKER_REGISTRY_PATH }}
       CONFIGURATION: Release
       DEV_VERSION_SUFFIX: 99.99.99
       DOTNET_SAMPLE_APP_IMAGE_NAME: dotnet-azurefunction
@@ -55,7 +55,7 @@ jobs:
         if: github.event_name != 'pull_request'
         run: |
           echo performing docker login
-          docker login -u ${{ secrets.DOCKER_REGISTRY_ID }} -p ${{ secrets.DOCKER_REGISTRY_PASS }}
+          docker login ${{ secrets.DOCKER_REGISTRY_URL }} -u ${{ secrets.DOCKER_REGISTRY_ID }} -p ${{ secrets.DOCKER_REGISTRY_PASS }}
           echo pushing docker image for ${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}
           echo image with tag ${{ env.APP_REGISTRY }}/${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}:${{ env.REL_VERSION }} will be pushed
           docker push ${{ env.APP_REGISTRY }}/${{ env.DOTNET_SAMPLE_APP_IMAGE_NAME }}:${{ env.REL_VERSION }}

--- a/docs/development/setup-ci.md
+++ b/docs/development/setup-ci.md
@@ -16,9 +16,10 @@ A GitHub account.
 
 | Name | Description |
 |--|--|
-| DOCKER_REGISTRY_ID | Username for Docker registry, required for uploading sample image|
-| DOCKER_REGISTRY_PASS | Password for Docker registry, required for uploading sample image|
-| DOCKER_REGISTRY | URL to Docker registry, required for uploading sample image |
+| DOCKER_REGISTRY_URL | URL of Docker registry, required for logging in to Docker registry, e.g. `myregistry.azurecr.io` |
+| DOCKER_REGISTRY_PATH | Path to store Docker images, required for uploading sample image, e.g. `samples/dotnet` |
+| DOCKER_REGISTRY_ID | Username for Docker registry, required for uploading sample image |
+| DOCKER_REGISTRY_PASS | Password for Docker registry, required for uploading sample image |
 | AZCOPY_SPA_APPLICATION_ID | Service principal application ID for AzCopy, required for uploading NuGet packages |
 | AZCOPY_SPA_CLIENT_SECRET | Service principal client secret for AzCopy, required for uploading NuGet packages |
 | GITHUB_TOKEN | GitHub token, required for creating release |


### PR DESCRIPTION
This PR allows authenticating to ghcr, acr, etc. instead of using docker.io as docker registry while logging in.