### PR TITLE
Add service invocation with HTTP output example

### DIFF
--- a/samples/dotnet-azurefunction/EchoServiceInvocation.cs
+++ b/samples/dotnet-azurefunction/EchoServiceInvocation.cs
@@ -1,0 +1,33 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+namespace dotnet_azurefunction
+{
+    using System;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.Dapr;
+    using Microsoft.Extensions.Logging;
+
+    public static class EchoServiceInvocation
+    {
+        // The function is triggered the service invocation Dapr trigger,
+        // and is echoes back the same message via a HTTP output binding.
+        [FunctionName("EchoServiceInvocation")]
+        public static IActionResult Run(
+            [DaprServiceInvocationTrigger] string message,
+            ILogger log)
+        {
+            log.LogInformation("C# function received a EchoServiceInvocation request.");
+
+            log.LogInformation($"Echoing message: {message}");
+
+            // Return the same payload.
+            return !String.IsNullOrWhiteSpace(message) ?
+                (ActionResult)new OkObjectResult(message) :
+                new BadRequestObjectResult("Please pass a message in the request body.");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds sample to show usage of service invocation trigger with HTTP output binding.

![image](https://github.com/Azure/azure-functions-dapr-extension/assets/22132944/6deac471-7edd-43cd-af49-07f072402faf)
