### PR TITLE
Fixed DaprBindingMessage JsonElement.ValueKind string issue

### DIFF
--- a/samples/dotnet-azurefunction/InvokeOutputBinding.cs
+++ b/samples/dotnet-azurefunction/InvokeOutputBinding.cs
@@ -23,7 +23,7 @@ namespace dotnet_azurefunction
         /// </summary>
         [FunctionName("InvokeOutputBinding")]
         public static async Task<IActionResult> Run(
-            [HttpTrigger(AuthorizationLevel.Function, "get", Route = "invoke/{appId}/{methodName}")] HttpRequest req,
+            [HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = "invoke/{appId}/{methodName}")] HttpRequest req,
             [DaprInvoke(AppId = "{appId}", MethodName = "{methodName}", HttpVerb = "post")] IAsyncCollector<InvokeMethodParameters> output,
             ILogger log)
         {

--- a/src/Microsoft.Azure.WebJobs.Extensions.Dapr/DaprExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Dapr/DaprExtensionConfigProvider.cs
@@ -201,6 +201,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr
 
         static DaprBindingMessage CreateBindingMessage(JsonElement jsonElement)
         {
+            if (jsonElement.ValueKind == JsonValueKind.String)
+            {
+                byte[] jsonBytes = Encoding.UTF8.GetBytes(jsonElement.GetString());
+                Utf8JsonReader reader = new Utf8JsonReader(jsonBytes);
+
+                if (JsonElement.TryParseValue(ref reader, out JsonElement? jsonElementObj) && jsonElementObj != null)
+                {
+                    return GetDaprBindingMessageObj(jsonElementObj.Value);
+                }
+                else
+                {
+                    throw new ArgumentException("Could not read jsonElement parameter.", nameof(jsonElement));
+                }
+            }
+
+            return GetDaprBindingMessageObj(jsonElement);
+        }
+
+        private static DaprBindingMessage GetDaprBindingMessageObj(JsonElement jsonElement)
+        {
             if (!jsonElement.TryGetProperty("data", out JsonElement data))
             {
                 throw new ArgumentException("A 'data' parameter is required for Dapr Binding operations.", nameof(jsonElement));

--- a/test/DaprExtensionTests/Tests/DaprBindingTests.cs
+++ b/test/DaprExtensionTests/Tests/DaprBindingTests.cs
@@ -87,8 +87,10 @@ namespace DaprExtensionTests
                         ""bindingName"": ""myBinding""
                    }}";
 
-            stringInput = stringInput.Replace("\r\n", string.Empty);
-            stringInput = stringInput.Replace("\n", string.Empty);
+            // Below string replacement is done to create a Json string with proper
+            // escaping which should result in JsonElement of ValueKind String on parsing.
+            stringInput = stringInput.Replace("\r\n", string.Empty); // This is done for windows as windows adds \r\n for new line.
+            stringInput = stringInput.Replace("\n", string.Empty); // This is done for Linux as Linux adds \n for new line.
             stringInput = stringInput.Replace("\"", "\\\"");
             stringInput = "\"" + stringInput + "\"";
             JsonDocument input = JsonDocument.Parse(stringInput);
@@ -107,6 +109,21 @@ namespace DaprExtensionTests
 
             Assert.Equal("/v1.0/bindings/myBinding", req.Path);
             Assert.Equal(JsonSerializer.Serialize(expectedPayload, Utils.DefaultSerializerOptions), req.ContentAsString);
+        }
+
+        [Fact]
+        public async Task SendMessage_JsonElementValueKindStringAsyncCollectorThrowsExceptionTest()
+        {
+            JsonDocument input = JsonDocument.Parse("\"Hello\"");
+
+            try
+            {
+                await this.CallFunctionAsync(nameof(Functions.JsonElementAsyncCollector), "input", input.RootElement);
+            }
+            catch (Exception ex)
+            {
+                Assert.Equal("Could not parse jsonElement parameter. (Parameter 'jsonElement')", ex.InnerException?.Message);
+            }
         }
 
         [Theory]

--- a/test/DaprExtensionTests/Tests/DaprBindingTests.cs
+++ b/test/DaprExtensionTests/Tests/DaprBindingTests.cs
@@ -9,6 +9,7 @@ namespace DaprExtensionTests
     using System.Collections.Generic;
     using System.Text.Json;
     using System.Threading.Tasks;
+    using DaprExtensionTests.Logging;
     using Microsoft.Azure.Functions.Extensions.Dapr.Core;
     using Microsoft.Azure.WebJobs;
     using Microsoft.Azure.WebJobs.Extensions.Dapr;
@@ -87,10 +88,9 @@ namespace DaprExtensionTests
                    }}";
 
             stringInput = stringInput.Replace("\r\n", string.Empty);
+            stringInput = stringInput.Replace("\n", string.Empty);
             stringInput = stringInput.Replace("\"", "\\\"");
             stringInput = "\"" + stringInput + "\"";
-
-            Console.WriteLine(stringInput);
 
             JsonDocument input = JsonDocument.Parse(stringInput);
 

--- a/test/DaprExtensionTests/Tests/DaprBindingTests.cs
+++ b/test/DaprExtensionTests/Tests/DaprBindingTests.cs
@@ -74,12 +74,11 @@ namespace DaprExtensionTests
             Assert.Equal(JsonSerializer.Serialize(expectedPayload, Utils.DefaultSerializerOptions), req.ContentAsString);
         }
 
-        [Theory]
-        [MemberData(nameof(GetObjectAsyncCollectorInputs))]
-        public async Task SendMessage_JsonElementValueKindStringAsyncCollector(object message)
+        [Fact]
+        public async Task SendMessage_JsonElementValueKindStringAsyncCollector()
         {
             string stringInput = $@"{{
-                        ""data"": {JsonSerializer.Serialize(message)},
+                        ""data"": ""Hello World"",
                         ""operation"": ""create"",
                         ""metadata"": {{
                             ""key"": ""myKey""
@@ -94,7 +93,7 @@ namespace DaprExtensionTests
 
             JsonDocument expectedPayload = JsonDocument.Parse(
                 $@"{{
-                        ""data"": {JsonSerializer.Serialize(message)},
+                        ""data"": ""Hello World"",
                         ""operation"": ""create"",
                         ""metadata"": {{
                             ""key"": ""myKey""

--- a/test/DaprExtensionTests/Tests/DaprBindingTests.cs
+++ b/test/DaprExtensionTests/Tests/DaprBindingTests.cs
@@ -89,6 +89,9 @@ namespace DaprExtensionTests
             stringInput = stringInput.Replace("\r\n", string.Empty);
             stringInput = stringInput.Replace("\"", "\\\"");
             stringInput = "\"" + stringInput + "\"";
+
+            Console.WriteLine(stringInput);
+
             JsonDocument input = JsonDocument.Parse(stringInput);
 
             JsonDocument expectedPayload = JsonDocument.Parse(

--- a/test/DaprExtensionTests/Tests/DaprBindingTests.cs
+++ b/test/DaprExtensionTests/Tests/DaprBindingTests.cs
@@ -8,7 +8,6 @@ namespace DaprExtensionTests
     using System;
     using System.Collections.Generic;
     using System.Text.Json;
-    using System.Text.RegularExpressions;
     using System.Threading.Tasks;
     using Microsoft.Azure.Functions.Extensions.Dapr.Core;
     using Microsoft.Azure.WebJobs;

--- a/test/DaprExtensionTests/Tests/DaprBindingTests.cs
+++ b/test/DaprExtensionTests/Tests/DaprBindingTests.cs
@@ -9,7 +9,6 @@ namespace DaprExtensionTests
     using System.Collections.Generic;
     using System.Text.Json;
     using System.Threading.Tasks;
-    using DaprExtensionTests.Logging;
     using Microsoft.Azure.Functions.Extensions.Dapr.Core;
     using Microsoft.Azure.WebJobs;
     using Microsoft.Azure.WebJobs.Extensions.Dapr;
@@ -75,11 +74,12 @@ namespace DaprExtensionTests
             Assert.Equal(JsonSerializer.Serialize(expectedPayload, Utils.DefaultSerializerOptions), req.ContentAsString);
         }
 
-        [Fact]
-        public async Task SendMessage_JsonElementValueKindStringAsyncCollector()
+        [Theory]
+        [MemberData(nameof(GetObjectAsyncCollectorInputs))]
+        public async Task SendMessage_JsonElementValueKindStringAsyncCollector(object message)
         {
             string stringInput = $@"{{
-                        ""data"": ""Hello World"",
+                        ""data"": {JsonSerializer.Serialize(message)},
                         ""operation"": ""create"",
                         ""metadata"": {{
                             ""key"": ""myKey""
@@ -91,12 +91,11 @@ namespace DaprExtensionTests
             stringInput = stringInput.Replace("\n", string.Empty);
             stringInput = stringInput.Replace("\"", "\\\"");
             stringInput = "\"" + stringInput + "\"";
-
             JsonDocument input = JsonDocument.Parse(stringInput);
 
             JsonDocument expectedPayload = JsonDocument.Parse(
                 $@"{{
-                        ""data"": ""Hello World"",
+                        ""data"": {JsonSerializer.Serialize(message)},
                         ""operation"": ""create"",
                         ""metadata"": {{
                             ""key"": ""myKey""


### PR DESCRIPTION
Current issue: When DaprServiceInvocation is called using DaprInvokeOutput binding, it sends JsonElement data as JsonElement.ValueKind = string, which results in exception (The requested operation requires an element of type 'Object', but the target element has type 'String'.)

This change will support both value kind Object and String.