### PR TITLE
Fixed property casing issue

### DIFF
--- a/samples/dotnet-isolated-azurefunction/OutputBinding/InvokeOutputBinding.cs
+++ b/samples/dotnet-isolated-azurefunction/OutputBinding/InvokeOutputBinding.cs
@@ -22,7 +22,7 @@ namespace dotnet_isolated_azurefunction
         [Function("InvokeOutputBinding")]
         [DaprInvokeOutput(AppId = "{appId}", MethodName = "{methodName}", HttpVerb = "post")]
         public static async Task<InvokeMethodParameters> Run(
-            [HttpTrigger(AuthorizationLevel.Function, "get", Route = "invoke/{appId}/{methodName}")] HttpRequestData req, FunctionContext functionContext)
+            [HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = "invoke/{appId}/{methodName}")] HttpRequestData req, FunctionContext functionContext)
         {
             var log = functionContext.GetLogger("InvokeOutputBinding");
             log.LogInformation("C# HTTP trigger function processed a request.");

--- a/src/Microsoft.Azure.WebJobs.Extensions.Dapr/DaprExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Dapr/DaprExtensionConfigProvider.cs
@@ -147,7 +147,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr
 
         static DaprPubSubEvent CreatePubSubEvent(JsonElement json)
         {
-            if (!json.TryGetProperty("payload", out JsonElement payload))
+            var propertyLookup = json.ToCaseInsensitiveDictionary();
+
+            if (!propertyLookup.TryGetValue("payload", out JsonElement payload))
             {
                 throw new ArgumentException($"A '{nameof(json).ToLowerInvariant()}' parameter is required for outbound pub/sub operations.");
             }
@@ -160,12 +162,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr
 
             DaprPubSubEvent event_ = new DaprPubSubEvent(payloadObject);
 
-            if (json.TryGetProperty("pubsubname", out JsonElement pubsubName))
+            if (propertyLookup.TryGetValue("pubsubname", out JsonElement pubsubName))
             {
                 event_.PubSubName = pubsubName.GetString();
             }
 
-            if (json.TryGetProperty("topic", out JsonElement topic))
+            if (propertyLookup.TryGetValue("topic", out JsonElement topic))
             {
                 event_.Topic = topic.GetString();
             }
@@ -227,7 +229,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr
 
         private static DaprBindingMessage GetDaprBindingMessageFromValueKindObject(JsonElement jsonElement)
         {
-            if (!jsonElement.TryGetProperty("data", out JsonElement data))
+            var propertyLookup = jsonElement.ToCaseInsensitiveDictionary();
+            if (!propertyLookup.TryGetValue("data", out JsonElement data))
             {
                 throw new ArgumentException("A 'data' parameter is required for Dapr Binding operations.", nameof(jsonElement));
             }
@@ -240,17 +243,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr
 
             DaprBindingMessage message = new DaprBindingMessage(dataObj);
 
-            if (jsonElement.TryGetProperty("operation", out JsonElement operation))
+            if (propertyLookup.TryGetValue("operation", out JsonElement operation))
             {
                 message.Operation = JsonSerializer.Deserialize<string>(operation);
             }
 
-            if (jsonElement.TryGetProperty("metadata", out JsonElement metadata))
+            if (propertyLookup.TryGetValue("metadata", out JsonElement metadata))
             {
                 message.Metadata = JsonSerializer.Deserialize<Dictionary<string, object>>(metadata);
             }
 
-            if (jsonElement.TryGetProperty("bindingName", out JsonElement binding))
+            if (propertyLookup.TryGetValue("bindingname", out JsonElement binding))
             {
                 message.BindingName = JsonSerializer.Deserialize<string>(binding);
             }
@@ -275,14 +278,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr
 
         internal static DaprStateRecord CreateSaveStateParameters(JsonElement parametersJson)
         {
-            if (!parametersJson.TryGetProperty("value", out JsonElement value))
+            var propertyLookup = parametersJson.ToCaseInsensitiveDictionary();
+            if (!propertyLookup.TryGetValue("value", out JsonElement value))
             {
                 throw new ArgumentException("A 'value' parameter is required for save-state operations.", nameof(parametersJson));
             }
 
             var parameters = new DaprStateRecord(value);
 
-            if (parametersJson.TryGetProperty("key", out JsonElement key))
+            if (propertyLookup.TryGetValue("key", out JsonElement key))
             {
                 parameters.Key = key.GetString();
             }
@@ -314,22 +318,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr
         {
             var options = new InvokeMethodParameters();
 
-            if (parametersJson.TryGetProperty("appId", out JsonElement appId))
+            var propertyLookup = parametersJson.ToCaseInsensitiveDictionary();
+
+            if (propertyLookup.TryGetValue("appid", out JsonElement appId))
             {
                 options.AppId = appId.GetRawText();
             }
 
-            if (parametersJson.TryGetProperty("methodName", out JsonElement methodName))
+            if (propertyLookup.TryGetValue("methodname", out JsonElement methodName))
             {
                 options.MethodName = methodName.GetRawText();
             }
 
-            if (parametersJson.TryGetProperty("body", out JsonElement body))
+            if (propertyLookup.TryGetValue("body", out JsonElement body))
             {
                 options.Body = body;
             }
 
-            if (parametersJson.TryGetProperty("httpVerb", out JsonElement httpVerb))
+            if (propertyLookup.TryGetValue("httpverb", out JsonElement httpVerb))
             {
                 options.HttpVerb = httpVerb.GetRawText();
             }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Dapr/DaprExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Dapr/DaprExtensionConfigProvider.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr
 
         static DaprPubSubEvent CreatePubSubEvent(JsonElement json)
         {
-            var propertyLookup = json.ToCaseInsensitiveDictionary();
+            var propertyBag = json.ToCaseInsensitiveDictionary();
 
             if (!propertyLookup.TryGetValue("payload", out JsonElement payload))
             {

--- a/src/Microsoft.Azure.WebJobs.Extensions.Dapr/DaprExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Dapr/DaprExtensionConfigProvider.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr
         {
             var propertyBag = json.ToCaseInsensitiveDictionary();
 
-            if (!propertyLookup.TryGetValue("payload", out JsonElement payload))
+            if (!propertyBag.TryGetValue("payload", out JsonElement payload))
             {
                 throw new ArgumentException($"A '{nameof(json).ToLowerInvariant()}' parameter is required for outbound pub/sub operations.");
             }
@@ -162,12 +162,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr
 
             DaprPubSubEvent event_ = new DaprPubSubEvent(payloadObject);
 
-            if (propertyLookup.TryGetValue("pubsubname", out JsonElement pubsubName))
+            if (propertyBag.TryGetValue("pubsubname", out JsonElement pubsubName))
             {
                 event_.PubSubName = pubsubName.GetString();
             }
 
-            if (propertyLookup.TryGetValue("topic", out JsonElement topic))
+            if (propertyBag.TryGetValue("topic", out JsonElement topic))
             {
                 event_.Topic = topic.GetString();
             }
@@ -229,8 +229,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr
 
         private static DaprBindingMessage GetDaprBindingMessageFromValueKindObject(JsonElement jsonElement)
         {
-            var propertyLookup = jsonElement.ToCaseInsensitiveDictionary();
-            if (!propertyLookup.TryGetValue("data", out JsonElement data))
+            var propertyBag = jsonElement.ToCaseInsensitiveDictionary();
+            if (!propertyBag.TryGetValue("data", out JsonElement data))
             {
                 throw new ArgumentException("A 'data' parameter is required for Dapr Binding operations.", nameof(jsonElement));
             }
@@ -243,17 +243,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr
 
             DaprBindingMessage message = new DaprBindingMessage(dataObj);
 
-            if (propertyLookup.TryGetValue("operation", out JsonElement operation))
+            if (propertyBag.TryGetValue("operation", out JsonElement operation))
             {
                 message.Operation = JsonSerializer.Deserialize<string>(operation);
             }
 
-            if (propertyLookup.TryGetValue("metadata", out JsonElement metadata))
+            if (propertyBag.TryGetValue("metadata", out JsonElement metadata))
             {
                 message.Metadata = JsonSerializer.Deserialize<Dictionary<string, object>>(metadata);
             }
 
-            if (propertyLookup.TryGetValue("bindingname", out JsonElement binding))
+            if (propertyBag.TryGetValue("bindingname", out JsonElement binding))
             {
                 message.BindingName = JsonSerializer.Deserialize<string>(binding);
             }
@@ -278,15 +278,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr
 
         internal static DaprStateRecord CreateSaveStateParameters(JsonElement parametersJson)
         {
-            var propertyLookup = parametersJson.ToCaseInsensitiveDictionary();
-            if (!propertyLookup.TryGetValue("value", out JsonElement value))
+            var propertyBag = parametersJson.ToCaseInsensitiveDictionary();
+            if (!propertyBag.TryGetValue("value", out JsonElement value))
             {
                 throw new ArgumentException("A 'value' parameter is required for save-state operations.", nameof(parametersJson));
             }
 
             var parameters = new DaprStateRecord(value);
 
-            if (propertyLookup.TryGetValue("key", out JsonElement key))
+            if (propertyBag.TryGetValue("key", out JsonElement key))
             {
                 parameters.Key = key.GetString();
             }
@@ -318,24 +318,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr
         {
             var options = new InvokeMethodParameters();
 
-            var propertyLookup = parametersJson.ToCaseInsensitiveDictionary();
+            var propertyBag = parametersJson.ToCaseInsensitiveDictionary();
 
-            if (propertyLookup.TryGetValue("appid", out JsonElement appId))
+            if (propertyBag.TryGetValue("appid", out JsonElement appId))
             {
                 options.AppId = appId.GetRawText();
             }
 
-            if (propertyLookup.TryGetValue("methodname", out JsonElement methodName))
+            if (propertyBag.TryGetValue("methodname", out JsonElement methodName))
             {
                 options.MethodName = methodName.GetRawText();
             }
 
-            if (propertyLookup.TryGetValue("body", out JsonElement body))
+            if (propertyBag.TryGetValue("body", out JsonElement body))
             {
                 options.Body = body;
             }
 
-            if (propertyLookup.TryGetValue("httpverb", out JsonElement httpVerb))
+            if (propertyBag.TryGetValue("httpverb", out JsonElement httpVerb))
             {
                 options.HttpVerb = httpVerb.GetRawText();
             }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Dapr/Utils/DictionaryUtils.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Dapr/Utils/DictionaryUtils.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr.Utils
         /// <returns>Dictionary.</returns>
         public static Dictionary<string, JsonElement> ToCaseInsensitiveDictionary(this JsonElement element)
         {
-            var propertyLookup = new Dictionary<string, JsonElement>(StringComparer.InvariantCultureIgnoreCase);
+            var propertyBag = new Dictionary<string, JsonElement>(StringComparer.InvariantCultureIgnoreCase);
 
             if (element.ValueKind == JsonValueKind.Null || element.ValueKind == JsonValueKind.Undefined)
             {

--- a/src/Microsoft.Azure.WebJobs.Extensions.Dapr/Utils/DictionaryUtils.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Dapr/Utils/DictionaryUtils.cs
@@ -25,18 +25,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr.Utils
 
             if (element.ValueKind == JsonValueKind.Null || element.ValueKind == JsonValueKind.Undefined)
             {
-                return propertyLookup;
+                return propertyBag;
             }
 
             foreach (var prop in element.EnumerateObject())
             {
                 if (element.TryGetProperty(prop.Name, out JsonElement value) && value.ValueKind != JsonValueKind.Null)
                 {
-                    propertyLookup[prop.Name] = value;
+                    propertyBag[prop.Name] = value;
                 }
             }
 
-            return propertyLookup;
+            return propertyBag;
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Dapr/Utils/DictionaryUtils.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Dapr/Utils/DictionaryUtils.cs
@@ -1,0 +1,42 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.WebJobs.Extensions.Dapr.Utils
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text.Json;
+
+    /// <summary>
+    /// Dictionary Utils.
+    /// </summary>
+    public static class DictionaryUtils
+    {
+        /// <summary>
+        /// Convert a JsonElement to a dictionary.
+        /// </summary>
+        /// <param name="element">JsonElement.</param>
+        /// <returns>Dictionary.</returns>
+        public static Dictionary<string, JsonElement> ToCaseInsensitiveDictionary(this JsonElement element)
+        {
+            var propertyLookup = new Dictionary<string, JsonElement>(StringComparer.InvariantCultureIgnoreCase);
+
+            if (element.ValueKind == JsonValueKind.Null || element.ValueKind == JsonValueKind.Undefined)
+            {
+                return propertyLookup;
+            }
+
+            foreach (var prop in element.EnumerateObject())
+            {
+                if (element.TryGetProperty(prop.Name, out JsonElement value) && value.ValueKind != JsonValueKind.Null)
+                {
+                    propertyLookup[prop.Name] = value;
+                }
+            }
+
+            return propertyLookup;
+        }
+    }
+}

--- a/test/DaprExtensionTests/UnitTests/Utils/DictionaryUtilsTests.cs
+++ b/test/DaprExtensionTests/UnitTests/Utils/DictionaryUtilsTests.cs
@@ -1,0 +1,104 @@
+namespace DaprExtensionTests.UnitTests.Utils
+{
+    using System.Text.Json;
+    using Microsoft.Azure.WebJobs.Extensions.Dapr.Utils;
+    using Xunit;
+
+    public class DictionaryUtilsTests
+    {
+        [Fact]
+        public void ToCaseInsensitiveDictionary_PositiveCases()
+        {
+            // Arrange
+            var json = @"{
+                ""Name"": ""John"",
+                ""Age"": 30,
+                ""City"": ""New York""
+            }";
+
+            var element = JsonDocument.Parse(json).RootElement;
+
+            // Act
+            var dictionary = element.ToCaseInsensitiveDictionary();
+
+            // Assert
+            Assert.Equal(3, dictionary.Count);
+            Assert.True(dictionary.ContainsKey("name"));
+            Assert.True(dictionary.ContainsKey("age"));
+            Assert.True(dictionary.ContainsKey("city"));
+            Assert.Equal("John", dictionary["name"].GetString());
+            Assert.Equal(30, dictionary["age"].GetInt32());
+            Assert.Equal("New York", dictionary["city"].GetString());
+        }
+
+        [Fact]
+        public void ToCaseInsensitiveDictionary_EmptyElement()
+        {
+            // Arrange
+            var json = @"{}";
+
+            var element = JsonDocument.Parse(json).RootElement;
+
+            // Act
+            var dictionary = element.ToCaseInsensitiveDictionary();
+
+            // Assert
+            Assert.Empty(dictionary);
+        }
+
+        [Fact]
+        public void ToCaseInsensitiveDictionary_NullValueProperties()
+        {
+            // Arrange
+            var json = @"{
+                ""Name"": null,
+                ""Age"": null
+            }";
+
+            var element = JsonDocument.Parse(json).RootElement;
+
+            // Act
+            var dictionary = element.ToCaseInsensitiveDictionary();
+
+            // Assert
+            Assert.Empty(dictionary);
+        }
+
+        [Fact]
+        public void ToCaseInsensitiveDictionary_NullElement()
+        {
+            // Arrange
+            JsonElement element = default;
+
+            // Act
+            var dictionary = element.ToCaseInsensitiveDictionary();
+
+            // Assert
+            Assert.Empty(dictionary);
+        }
+
+        [Fact]
+        public void ToCaseInsensitiveDictionary_DuplicateProperties()
+        {
+            // Arrange
+            var json = @"{
+                ""Name"": ""John"",
+                ""name"": ""Doe"",
+                ""Age"": 30
+            }";
+
+            var element = JsonDocument.Parse(json).RootElement;
+
+            // Act
+            var dictionary = element.ToCaseInsensitiveDictionary();
+
+            // Assert
+            Assert.Equal(2, dictionary.Count);
+            Assert.True(dictionary.ContainsKey("name"));
+            Assert.True(dictionary.ContainsKey("age"));
+            Assert.Equal("Doe", dictionary["name"].GetString()); // The last occurrence should overwrite the previous one
+            Assert.Equal(30, dictionary["age"].GetInt32());
+        }
+    }
+
+}

--- a/test/DaprExtensionTests/UnitTests/Utils/EnvironmentExtensionsTests.cs
+++ b/test/DaprExtensionTests/UnitTests/Utils/EnvironmentExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿namespace DaprExtensionTests.UnitTests.Services
+﻿namespace DaprExtensionTests.UnitTests.Utils
 {
     using Microsoft.Azure.WebJobs;
     using Microsoft.Azure.WebJobs.Extensions.Dapr;


### PR DESCRIPTION
Fixed issues related to property casing, for example, body property in python could come as "body" and same will come in dotnet-isolated "Body". This PR have made all the changes to make property check case insensitive for all the bindings.