### PR TITLE
fix #151 add *-* to supported version.

### DIFF
--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Dapr/Microsoft.Azure.Functions.Worker.Extensions.Dapr.csproj
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Dapr/Microsoft.Azure.Functions.Worker.Extensions.Dapr.csproj
@@ -13,7 +13,7 @@
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <!-- Default version for dev -->
     <Version>99.99.99</Version>
-    <SupportedVersion>99.99.99</SupportedVersion>
+    <SupportedVersion>0.16.*-*</SupportedVersion>
     <PackageTags>Microsoft Azure WebJobs Azure-Functions Isolated Dotnet-Isolated Dapr Worker</PackageTags>
   </PropertyGroup>
 


### PR DESCRIPTION
This fixes: #151 


So what I can gather, when a build runs, the Isolated worker runtime generates a `WorkerExtensions.csproj` and tries to download referenced dependencies from from nuget. 


```
<Project Sdk="Microsoft.NET.Sdk">
    <PropertyGroup>
        <TargetFramework>net6.0</TargetFramework>
        <LangVersion>preview</LangVersion>
        <Configuration>Release</Configuration>
        <AssemblyName>Microsoft.Azure.Functions.Worker.Extensions</AssemblyName>
        <RootNamespace>Microsoft.Azure.Functions.Worker.Extensions</RootNamespace>
        <MajorMinorProductVersion>1.0</MajorMinorProductVersion>
        <Version>$(MajorMinorProductVersion).0</Version>
        <AssemblyVersion>$(MajorMinorProductVersion).0.0</AssemblyVersion>
        <FileVersion>$(Version)</FileVersion>
        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
    </PropertyGroup>
    <ItemGroup>
        <PackageReference Include="Microsoft.NETCore.Targets" Version="3.0.0" PrivateAssets="all" />
        <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
        <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Dapr" Version="99.99.99" />

    </ItemGroup>
</Project>
```

I'd be keen to understand why this "proxy" project gets generated, my first guess it's how the isolated worker runtime hooks up the bindings to the code - but that's just a guess.

I had a little look at the Durable Functions Extension and they seem to hit a similar roadblock.

https://github.com/Azure/azure-functions-durable-extension/blob/dev/src/Worker.Extensions.DurableTask/AssemblyInfo.cs

I've noticed in their examples they don't reference the local csproj's either. 

I know this PR isn't probably a long term fix nor the most ideal, but I'd like to unblock my self with my experiment. 

Cheers,

P