### PR TITLE
adding azcopy tennant id

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,6 +143,6 @@ jobs:
 
           # Upload nuget packages to Azure blob storage
           export AZCOPY_SPA_CLIENT_SECRET=${{ secrets.AZCOPY_SPA_CLIENT_SECRET }}
-          ./azcopy login --service-principal --application-id ${{ secrets.AZCOPY_SPA_APPLICATION_ID }}
+          ./azcopy login --service-principal --application-id ${{ secrets.AZCOPY_SPA_APPLICATION_ID }} --tenant-id=${{ secrets.AZCOPY_TENANT_ID }}
           ./azcopy copy "${{ env.NUPKG_OUTDIR }}/*" "https://azuresdkpartnerdrops.blob.core.windows.net/drops/azure-functions-dapr-extension/dotnet/${{ env.REL_VERSION }}/"
           ./azcopy copy "${{ env.MAVEN_OUTDIR }}/*" "https://azuresdkpartnerdrops.blob.core.windows.net/drops/azure-functions-dapr-extension/java/${{ env.REL_VERSION }}/" --recursive=true

--- a/docs/development/setup-ci.md
+++ b/docs/development/setup-ci.md
@@ -20,11 +20,11 @@ A GitHub account.
 | DOCKER_REGISTRY_PATH | Path to store Docker images, required for uploading sample image, e.g. `samples/dotnet` |
 | DOCKER_REGISTRY_ID | Username for Docker registry, required for uploading sample image |
 | DOCKER_REGISTRY_PASS | Password for Docker registry, required for uploading sample image |
-| AZCOPY_SPA_APPLICATION_ID | Service principal application ID for AzCopy, required for uploading NuGet packages |
-| AZCOPY_SPA_CLIENT_SECRET | Service principal client secret for AzCopy, required for uploading NuGet packages |
+| AZCOPY_SPA_APPLICATION_ID | Service principal application ID for AzCopy, required for uploading NuGet and Maven packages |
+| AZCOPY_SPA_CLIENT_SECRET | Service principal client secret for AzCopy, required for uploading NuGet and Maven packages |
 | GITHUB_TOKEN | GitHub token, required for creating release |
 | CODECOV_TOKEN | Codecov token, required for uploading code coverage results |
-| AZCOPY_TENANT_ID | Tenant Id, required for autheticating azure blob cotainer |
+| AZCOPY_TENANT_ID | Tenant ID used by AzCopy to authenticate, required for uploading artifacts |
 
 Notes
 - `GITHUB_TOKEN` is automatically set by GitHub Actions, so you don't need to set it manually.

--- a/docs/development/setup-ci.md
+++ b/docs/development/setup-ci.md
@@ -24,7 +24,7 @@ A GitHub account.
 | AZCOPY_SPA_CLIENT_SECRET | Service principal client secret for AzCopy, required for uploading NuGet and Maven packages |
 | GITHUB_TOKEN | GitHub token, required for creating release |
 | CODECOV_TOKEN | Codecov token, required for uploading code coverage results |
-| AZCOPY_TENANT_ID | Tenant ID used by AzCopy to authenticate, required for uploading artifacts |
+| AZCOPY_TENANT_ID | Tenant ID used by AzCopy to authenticate, required for uploading NuGet and Maven artifacts |
 
 Notes
 - `GITHUB_TOKEN` is automatically set by GitHub Actions, so you don't need to set it manually.

--- a/docs/development/setup-ci.md
+++ b/docs/development/setup-ci.md
@@ -22,9 +22,9 @@ A GitHub account.
 | DOCKER_REGISTRY_PASS | Password for Docker registry, required for uploading sample image |
 | AZCOPY_SPA_APPLICATION_ID | Service principal application ID for AzCopy, required for uploading NuGet and Maven packages |
 | AZCOPY_SPA_CLIENT_SECRET | Service principal client secret for AzCopy, required for uploading NuGet and Maven packages |
+| AZCOPY_TENANT_ID | Tenant ID used by AzCopy to authenticate, required for uploading NuGet and Maven artifacts |
 | GITHUB_TOKEN | GitHub token, required for creating release |
 | CODECOV_TOKEN | Codecov token, required for uploading code coverage results |
-| AZCOPY_TENANT_ID | Tenant ID used by AzCopy to authenticate, required for uploading NuGet and Maven artifacts |
 
 Notes
 - `GITHUB_TOKEN` is automatically set by GitHub Actions, so you don't need to set it manually.

--- a/docs/development/setup-ci.md
+++ b/docs/development/setup-ci.md
@@ -20,8 +20,8 @@ A GitHub account.
 | DOCKER_REGISTRY_PATH | Path to store Docker images, required for uploading sample image, e.g. `samples/dotnet` |
 | DOCKER_REGISTRY_ID | Username for Docker registry, required for uploading sample image |
 | DOCKER_REGISTRY_PASS | Password for Docker registry, required for uploading sample image |
-| AZCOPY_SPA_APPLICATION_ID | Service principal application ID for AzCopy, required for uploading NuGet and Maven packages |
-| AZCOPY_SPA_CLIENT_SECRET | Service principal client secret for AzCopy, required for uploading NuGet and Maven packages |
+| AZCOPY_SPA_APPLICATION_ID | Service principal application ID for AzCopy, required for uploading NuGet and Maven artifacts |
+| AZCOPY_SPA_CLIENT_SECRET | Service principal client secret for AzCopy, required for uploading NuGet and Maven artifacts |
 | AZCOPY_TENANT_ID | Tenant ID used by AzCopy to authenticate, required for uploading NuGet and Maven artifacts |
 | GITHUB_TOKEN | GitHub token, required for creating release |
 | CODECOV_TOKEN | Codecov token, required for uploading code coverage results |

--- a/docs/development/setup-ci.md
+++ b/docs/development/setup-ci.md
@@ -24,6 +24,7 @@ A GitHub account.
 | AZCOPY_SPA_CLIENT_SECRET | Service principal client secret for AzCopy, required for uploading NuGet packages |
 | GITHUB_TOKEN | GitHub token, required for creating release |
 | CODECOV_TOKEN | Codecov token, required for uploading code coverage results |
+| AZCOPY_TENANT_ID | Tenant Id, required for autheticating azure blob cotainer |
 
 Notes
 - `GITHUB_TOKEN` is automatically set by GitHub Actions, so you don't need to set it manually.


### PR DESCRIPTION
Azure storage account used for publishing the nuget package is changed to single tenant. So, this PR adds a tenant_id to fix the azcopy login issue by adding the --tenant-id parameter in azcopy.

Error message without tenant_id

`"AADSTS50194: Application '***'(azuresdkpartnerdrops) is not configured as a multi-tenant application. Usage of the /common endpoint is not supported for such applications created after '10/15/2018'. Use a tenant-specific endpoint or configure the application to be multi-tenant.`