### PR TITLE
Updating deprecated flag from documentation

### DIFF
--- a/samples/dotnet-azurefunction/README.md
+++ b/samples/dotnet-azurefunction/README.md
@@ -53,12 +53,12 @@ Run function host with Dapr:
 
 Windows
 ```
-dapr run --app-id functionapp --app-port 3001 --dapr-http-port 3501 --components-path ..\components\ -- func host start
+dapr run --app-id functionapp --app-port 3001 --dapr-http-port 3501 --resources-path ..\components\ -- func host start
 ```
 
 Linux/Mac OS
 ```
-dapr run --app-id functionapp --app-port 3001 --dapr-http-port 3501 --components-path ../components/ -- func host start
+dapr run --app-id functionapp --app-port 3001 --dapr-http-port 3501 --resources-path ../components/ -- func host start
 ```
 
 The command should output the dapr logs that look like the following:

--- a/samples/java-azurefunction/README.md
+++ b/samples/java-azurefunction/README.md
@@ -72,12 +72,12 @@ Run function host with Dapr:
 
 Windows
 ```
-dapr run --app-id functionapp --app-port 3001 --dapr-http-port 3501 --components-path ..\components\ -- mvn azure-functions:run
+dapr run --app-id functionapp --app-port 3001 --dapr-http-port 3501 --resources-path ..\components\ -- mvn azure-functions:run
 ```
 
 Linux/Mac OS
 ```
-dapr run --app-id functionapp --app-port 3001 --dapr-http-port 3501 --components-path ../components/ -- mvn azure-functions:run
+dapr run --app-id functionapp --app-port 3001 --dapr-http-port 3501 --resources-path ../components/ -- mvn azure-functions:run
 ```
 
 The command should output the dapr logs that look like the following:

--- a/samples/javascript-azurefunction/README.md
+++ b/samples/javascript-azurefunction/README.md
@@ -72,17 +72,17 @@ Run function host with Dapr:
 
 Windows
 ```
-dapr run --app-id functionapp --app-port 3001 --dapr-http-port 3501  --components-path ..\components\ -- func host start --no-build
+dapr run --app-id functionapp --app-port 3001 --dapr-http-port 3501  --resources-path ..\components\ -- func host start --no-build
 ```
 
 Linux/MacOS
 ```
-dapr run --app-id functionapp --app-port 3001 --dapr-http-port 3501  --components-path ../components/ -- func host start --no-build
+dapr run --app-id functionapp --app-port 3001 --dapr-http-port 3501  --resources-path ../components/ -- func host start --no-build
 ```
 
 Linux/MacOS
 ```
-dapr run --app-id functionapp --app-port 3001 --dapr-http-port 3501  --components-path ../components/ -- func host start --no-build
+dapr run --app-id functionapp --app-port 3001 --dapr-http-port 3501  --resources-path ../components/ -- func host start --no-build
 ```
 
 The command should output the dapr logs that look like the following:

--- a/samples/javascript-v4-azurefunction/README.md
+++ b/samples/javascript-v4-azurefunction/README.md
@@ -72,17 +72,17 @@ Run function host with Dapr:
 
 Windows
 ```
-dapr run --app-id functionapp --app-port 3001 --dapr-http-port 3501  --components-path ..\components\ -- func host start --no-build
+dapr run --app-id functionapp --app-port 3001 --dapr-http-port 3501  --resources-path ..\components\ -- func host start --no-build
 ```
 
 Linux/MacOS
 ```
-dapr run --app-id functionapp --app-port 3001 --dapr-http-port 3501  --components-path ../components/ -- func host start --no-build
+dapr run --app-id functionapp --app-port 3001 --dapr-http-port 3501  --resources-path ../components/ -- func host start --no-build
 ```
 
 Linux/MacOS
 ```
-dapr run --app-id functionapp --app-port 3001 --dapr-http-port 3501  --components-path ../components/ -- func host start --no-build
+dapr run --app-id functionapp --app-port 3001 --dapr-http-port 3501  --resources-path ../components/ -- func host start --no-build
 ```
 
 The command should output the dapr logs that look like the following:

--- a/samples/javascript-v4-azurefunction/src/functions/stateOutputBinding.js
+++ b/samples/javascript-v4-azurefunction/src/functions/stateOutputBinding.js
@@ -1,6 +1,6 @@
 const { app, output, trigger } = require('@azure/functions');
 
-const daprStateOuput = output.generic({
+const daprStateOutput = output.generic({
     type: "daprState",
     stateStore: "%StateStoreName%",
     direction: "out",
@@ -16,7 +16,7 @@ app.generic('StateOutputBinding', {
         route: "state/{key}",
         name: "req"
     }),
-    return: daprStateOuput,
+    return: daprStateOutput,
     handler: async (request, context) => {
         context.log("Node HTTP trigger function processed a request.");
 

--- a/samples/powershell-azurefunction/README.md
+++ b/samples/powershell-azurefunction/README.md
@@ -70,16 +70,16 @@ Note that this extensions.csproj file is required in order to reference the exce
 func extensions install -p Microsoft.Azure.WebJobs.Extensions.Dapr -v <version>
 ```
 
-Run function host with Dapr. `--components-path` flag specifies the directory stored all Dapr Components for this sample. They should be language ignostic.
+Run function host with Dapr. `--resources-path` flag specifies the directory stored all Dapr Components for this sample. They should be language ignostic.
 
 Windows
 ```
-dapr run --app-id functionapp --app-port 3001  --components-path ..\components\ -- func host start 
+dapr run --app-id functionapp --app-port 3001  --resources-path ..\components\ -- func host start 
 ```
 
 Linux/MacOS
 ```
-dapr run --app-id functionapp --app-port 3001  --components-path ../components/ -- func host start 
+dapr run --app-id functionapp --app-port 3001  --resources-path ../components/ -- func host start 
 ```
 
 The command should output the dapr logs that look like the following:

--- a/samples/python-azurefunction/README.md
+++ b/samples/python-azurefunction/README.md
@@ -73,16 +73,16 @@ Note that this extensions.csproj file is required in order to reference the exce
 func extensions install -p Microsoft.Azure.WebJobs.Extensions.Dapr -v <version>
 ```
 
-Run function host with Dapr. `--components-path` flag specifies the directory stored all Dapr Components for this sample. They should be language ignostic.
+Run function host with Dapr. `--resources-path` flag specifies the directory stored all Dapr Components for this sample. They should be language ignostic.
 
 Windows
 ```
-dapr run --app-id functionapp --app-port 3001  --components-path ..\components\ -- func host start 
+dapr run --app-id functionapp --app-port 3001  --resources-path ..\components\ -- func host start 
 ```
 
 Linux/MacOS
 ```
-dapr run --app-id functionapp --app-port 3001  --components-path ../components/ -- func host start 
+dapr run --app-id functionapp --app-port 3001  --resources-path ../components/ -- func host start 
 ```
 
 The command should output the dapr logs that look like the following:

--- a/samples/python-v2-azurefunction/README.md
+++ b/samples/python-v2-azurefunction/README.md
@@ -74,16 +74,16 @@ Note that this extensions.csproj file is required in order to reference the exce
 func extensions install -p Microsoft.Azure.WebJobs.Extensions.Dapr -v <version>
 ```
 
-Run function host with Dapr. `--components-path` flag specifies the directory stored all Dapr Components for this sample. They should be language ignostic.
+Run function host with Dapr. `--resources-path` flag specifies the directory stored all Dapr Components for this sample. They should be language ignostic.
 
 Windows
 ```
-dapr run --app-id functionapp --app-port 3001  --components-path ..\components\ -- func host start 
+dapr run --app-id functionapp --app-port 3001  --resources-path ..\components\ -- func host start 
 ```
 
 Linux/MacOS
 ```
-dapr run --app-id functionapp --app-port 3001  --components-path ../components/ -- func host start 
+dapr run --app-id functionapp --app-port 3001  --resources-path ../components/ -- func host start 
 ```
 
 The command should output the dapr logs that look like the following:

--- a/troubleshooting-guide.md
+++ b/troubleshooting-guide.md
@@ -79,7 +79,7 @@ Dapr sidecar is not present. Please see (https://aka.ms/azure-functions-dapr-sid
     ```
 - If you are running your Azure Function locally, make sure you are [running the function app with Dapr](https://github.com/ASHIQUEMD/azure-functions-dapr-extension/tree/master/samples/python-v2-azurefunction#step-2---run-function-app-with-dapr). Execute the following command:
     ```bash
-    dapr run --app-id functionapp --app-port 3001  --components-path ..\components\ -- func host start 
+    dapr run --app-id functionapp --app-port 3001  --resources-path ..\components\ -- func host start 
     ```
 
 **Preventive Measures:** To prevent this error, always ensure that Dapr is properly set up and enabled in your environment before using Dapr bindings and triggers with Azure Functions.
@@ -126,7 +126,7 @@ annotations:
 - For local development, make sure to provide --app-port when running the Function app with Dapr:
 
 ```
-dapr run --app-id functionapp --app-port 3001 --components-path ..\components\ -- func host start 
+dapr run --app-id functionapp --app-port 3001 --resources-path ..\components\ -- func host start 
 ```
 
 **Preventive Measures:** To prevent this error, always configure the app-port parameter correctly in your Dapr setup.


### PR DESCRIPTION
- Changing `--components-path` to `--resources-path`
- Fixing typo in variable name