### PR TITLE
Adding steps to run python v2 samples

### DIFF
--- a/samples/javascript-azurefunction/README.md
+++ b/samples/javascript-azurefunction/README.md
@@ -62,7 +62,7 @@ Build the function app:
 dotnet build -o bin extensions.csproj
 ```
 
-Alternatively you can install the Dapr extension, run the following command. Get the `version` from [here](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.Dapr).
+Alternatively, you can install the Dapr extension by running the following command. Retrieve the latest `version` from [here](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.Dapr).
 
 ```
 func extensions install -p Microsoft.Azure.WebJobs.Extensions.Dapr -v <version>

--- a/samples/javascript-azurefunction/README.md
+++ b/samples/javascript-azurefunction/README.md
@@ -80,11 +80,6 @@ Linux/MacOS
 dapr run --app-id functionapp --app-port 3001 --dapr-http-port 3501  --resources-path ../components/ -- func host start --no-build
 ```
 
-Linux/MacOS
-```
-dapr run --app-id functionapp --app-port 3001 --dapr-http-port 3501  --resources-path ../components/ -- func host start --no-build
-```
-
 The command should output the dapr logs that look like the following:
 
 ```

--- a/samples/javascript-azurefunction/README.md
+++ b/samples/javascript-azurefunction/README.md
@@ -62,7 +62,7 @@ Build the function app:
 dotnet build -o bin extensions.csproj
 ```
 
-Note that this extensions.csproj file is required in order to reference the exception as a project rather than as an nuget package. To do the equivalent step with a published version of the extension on nuget.org, run the following step:
+Alternatively you can install the Dapr extension, run the following command. Get the `version` from [here](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.Dapr).
 
 ```
 func extensions install -p Microsoft.Azure.WebJobs.Extensions.Dapr -v <version>

--- a/samples/javascript-v4-azurefunction/README.md
+++ b/samples/javascript-v4-azurefunction/README.md
@@ -62,7 +62,7 @@ Build the function app:
 dotnet build -o bin extensions.csproj
 ```
 
-Alternatively you can install the Dapr extension, run the following command. Get the `version` from [here](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.Dapr).
+Alternatively, you can install the Dapr extension by running the following command. Retrieve the latest `version` from [here](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.Dapr).
 
 ```
 func extensions install -p Microsoft.Azure.WebJobs.Extensions.Dapr -v <version>

--- a/samples/javascript-v4-azurefunction/README.md
+++ b/samples/javascript-v4-azurefunction/README.md
@@ -80,11 +80,6 @@ Linux/MacOS
 dapr run --app-id functionapp --app-port 3001 --dapr-http-port 3501  --resources-path ../components/ -- func host start --no-build
 ```
 
-Linux/MacOS
-```
-dapr run --app-id functionapp --app-port 3001 --dapr-http-port 3501  --resources-path ../components/ -- func host start --no-build
-```
-
 The command should output the dapr logs that look like the following:
 
 ```

--- a/samples/javascript-v4-azurefunction/README.md
+++ b/samples/javascript-v4-azurefunction/README.md
@@ -62,7 +62,7 @@ Build the function app:
 dotnet build -o bin extensions.csproj
 ```
 
-Note that this extensions.csproj file is required in order to reference the exception as a project rather than as an nuget package. To do the equivalent step with a published version of the extension on nuget.org, run the following step:
+Alternatively you can install the Dapr extension, run the following command. Get the `version` from [here](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.Dapr).
 
 ```
 func extensions install -p Microsoft.Azure.WebJobs.Extensions.Dapr -v <version>

--- a/samples/powershell-azurefunction/README.md
+++ b/samples/powershell-azurefunction/README.md
@@ -64,7 +64,7 @@ Build the function app:
 dotnet build -o bin/ extensions.csproj
 ```
 
-Alternatively you can install the Dapr extension, run the following command. Get the `version` from [here](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.Dapr).
+Alternatively, you can install the Dapr extension by running the following command. Retrieve the latest `version` from [here](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.Dapr).
 
 ```
 func extensions install -p Microsoft.Azure.WebJobs.Extensions.Dapr -v <version>

--- a/samples/powershell-azurefunction/README.md
+++ b/samples/powershell-azurefunction/README.md
@@ -64,7 +64,7 @@ Build the function app:
 dotnet build -o bin/ extensions.csproj
 ```
 
-Note that this extensions.csproj file is required in order to reference the exception as a project rather than as an nuget package. To do the equivalent step with a published version of the extension on nuget.org, run the following step:
+Alternatively you can install the Dapr extension, run the following command. Get the `version` from [here](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.Dapr).
 
 ```
 func extensions install -p Microsoft.Azure.WebJobs.Extensions.Dapr -v <version>

--- a/samples/python-azurefunction/README.md
+++ b/samples/python-azurefunction/README.md
@@ -67,7 +67,7 @@ Build the function app:
 dotnet build -o bin/ extensions.csproj
 ```
 
-Alternatively you can install the Dapr extension, run the following command. Get the `version` from [here](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.Dapr).
+Alternatively, you can install the Dapr extension by running the following command. Retrieve the latest `version` from [here](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.Dapr).
 
 ```
 func extensions install -p Microsoft.Azure.WebJobs.Extensions.Dapr -v <version>

--- a/samples/python-azurefunction/README.md
+++ b/samples/python-azurefunction/README.md
@@ -67,7 +67,7 @@ Build the function app:
 dotnet build -o bin/ extensions.csproj
 ```
 
-Note that this extensions.csproj file is required in order to reference the exception as a project rather than as an nuget package. To do the equivalent step with a published version of the extension on nuget.org, run the following step:
+Alternatively you can install the Dapr extension, run the following command. Get the `version` from [here](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.Dapr).
 
 ```
 func extensions install -p Microsoft.Azure.WebJobs.Extensions.Dapr -v <version>

--- a/samples/python-v2-azurefunction/README.md
+++ b/samples/python-v2-azurefunction/README.md
@@ -68,7 +68,7 @@ The Python v2 programming model introduces the concept of blueprints. A blueprin
 dotnet build -o bin/ extensions.csproj
 ```
 
-Note that this extensions.csproj file is required in order to reference the exception as a project rather than as an nuget package. To do the equivalent step with a [published version](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.Dapr) of the extension on nuget.org, run the following step:
+Alternatively you can install the Dapr extension, run the following command. Get the `version` from [here](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.Dapr).
 
 ```
 func extensions install -p Microsoft.Azure.WebJobs.Extensions.Dapr -v <version>
@@ -81,16 +81,16 @@ py -m venv .venv
 .venv\scripts\activate
 ```
 
-#### In your requirements.text file, add the following line:
-
-```bash
-azure-functions==1.18.0b3
-```
-
 #### Install the Dapr python library
 
 ```bash
 pip install -r .\requirements.txt
+```
+
+#### Modify your `local.setting.json` file with the following configuration:
+
+```bash
+"PYTHON_ISOLATE_WORKER_DEPENDENCIES":1
 ```
 
 #### Run function host with Dapr. `--resources-path` flag specifies the directory stored all Dapr Components for this sample. They should be language ignostic.

--- a/samples/python-v2-azurefunction/README.md
+++ b/samples/python-v2-azurefunction/README.md
@@ -62,19 +62,38 @@ The Python v2 programming model introduces the concept of blueprints. A blueprin
 
 # Step 2 - Run Function App with Dapr
 
-Build the function app:
+#### Build the function app:
 
 ```
 dotnet build -o bin/ extensions.csproj
 ```
 
-Note that this extensions.csproj file is required in order to reference the exception as a project rather than as an nuget package. To do the equivalent step with a published version of the extension on nuget.org, run the following step:
+Note that this extensions.csproj file is required in order to reference the exception as a project rather than as an nuget package. To do the equivalent step with a [published version](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.Dapr) of the extension on nuget.org, run the following step:
 
 ```
 func extensions install -p Microsoft.Azure.WebJobs.Extensions.Dapr -v <version>
 ```
 
-Run function host with Dapr. `--resources-path` flag specifies the directory stored all Dapr Components for this sample. They should be language ignostic.
+#### Create and activate a virtual environment
+
+```PowerShell
+py -m venv .venv
+.venv\scripts\activate
+```
+
+#### In your requirements.text file, add the following line:
+
+```bash
+azure-functions==1.18.0b3
+```
+
+#### Install the Dapr python library
+
+```bash
+pip install -r .\requirements.txt
+```
+
+#### Run function host with Dapr. `--resources-path` flag specifies the directory stored all Dapr Components for this sample. They should be language ignostic.
 
 Windows
 ```

--- a/samples/python-v2-azurefunction/README.md
+++ b/samples/python-v2-azurefunction/README.md
@@ -68,7 +68,7 @@ The Python v2 programming model introduces the concept of blueprints. A blueprin
 dotnet build -o bin/ extensions.csproj
 ```
 
-Alternatively you can install the Dapr extension, run the following command. Get the `version` from [here](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.Dapr).
+Alternatively, you can install the Dapr extension by running the following command. Retrieve the latest `version` from [here](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.Dapr).
 
 ```
 func extensions install -p Microsoft.Azure.WebJobs.Extensions.Dapr -v <version>
@@ -221,7 +221,14 @@ def main(payload, data: str) :
 ```
 
 Similarly, the function will be triggered by any `RetrieveOrder` service invocation request such as:
+
+Windows Command Prompt
+```sh
+dapr invoke --app-id functionapp --method RetrieveOrder --data "{}"
 ```
+
+Linux or MacOS
+```sh
 dapr invoke --app-id functionapp --method RetrieveOrder --data '{}'
 ```
 

--- a/samples/python-v2-azurefunction/README.md
+++ b/samples/python-v2-azurefunction/README.md
@@ -77,7 +77,7 @@ func extensions install -p Microsoft.Azure.WebJobs.Extensions.Dapr -v <version>
 #### Create and activate a virtual environment
 
 ```PowerShell
-py -m venv .venv
+python -m venv .venv
 .venv\scripts\activate
 ```
 

--- a/samples/python-v2-azurefunction/requirements.txt
+++ b/samples/python-v2-azurefunction/requirements.txt
@@ -1,1 +1,1 @@
-azure-functions
+azure-functions==1.18.0b3


### PR DESCRIPTION
Updating docs to 
- Create virtual environment
- activate it
- install requirement.txt