### PR TITLE
Loggin for every functions binding as a separate category

### DIFF
--- a/samples/javascript-v4-azurefunction/src/functions/stateOutputBinding.js
+++ b/samples/javascript-v4-azurefunction/src/functions/stateOutputBinding.js
@@ -1,6 +1,6 @@
 const { app, output, trigger } = require('@azure/functions');
 
-const daprStateOuput = output.generic({
+const daprStateOutput = output.generic({
     type: "daprState",
     stateStore: "%StateStoreName%",
     direction: "out",
@@ -16,7 +16,7 @@ app.generic('StateOutputBinding', {
         route: "state/{key}",
         name: "req"
     }),
-    return: daprStateOuput,
+    return: daprStateOutput,
     handler: async (request, context) => {
         context.log("Node HTTP trigger function processed a request.");
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.Dapr/Services/DaprServiceListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Dapr/Services/DaprServiceListener.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr.Services
 
             try
             {
-                var res = await this.daprClient.GetAsync($"{this.daprAddress}/v1.0/metadata", cancellationToken);
+                var res = await this.daprClient.GetAsync(this.logger, $"{this.daprAddress}/v1.0/metadata", cancellationToken);
                 resBody = await res.Content.ReadAsStringAsync();
                 if (res.StatusCode != System.Net.HttpStatusCode.OK)
                 {

--- a/src/Microsoft.Azure.WebJobs.Extensions.Dapr/Services/IDaprClient.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Dapr/Services/IDaprClient.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr.Services
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Extensions.Logging;
 
     /// <summary>
     /// Dapr client interface.
@@ -17,26 +18,29 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr.Services
         /// <summary>
         /// Dapr Http Get call.
         /// </summary>
+        /// <param name="logger">Logger.</param>
         /// <param name="uri">Dapr endpoint.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task<HttpResponseMessage> GetAsync(string uri, CancellationToken cancellationToken);
+        Task<HttpResponseMessage> GetAsync(ILogger logger, string uri, CancellationToken cancellationToken);
 
         /// <summary>
         /// Dapr Http Post call.
         /// </summary>
+        /// /// <param name="logger">Logger.</param>
         /// <param name="uri">Dapr endpoint.</param>
         /// <param name="stringContent">String content.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task<HttpResponseMessage> PostAsync(string uri, StringContent stringContent, CancellationToken cancellationToken);
+        Task<HttpResponseMessage> PostAsync(ILogger logger, string uri, StringContent stringContent, CancellationToken cancellationToken);
 
         /// <summary>
         /// Dapr Http Send call.
         /// </summary>
+        /// /// <param name="logger">Logger.</param>
         /// <param name="httpRequestMessage">HttpRequestMessage.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task<HttpResponseMessage> SendAsync(HttpRequestMessage httpRequestMessage, CancellationToken cancellationToken);
+        Task<HttpResponseMessage> SendAsync(ILogger logger, HttpRequestMessage httpRequestMessage, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Dapr/Utils/LoggingUtils.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Dapr/Utils/LoggingUtils.cs
@@ -20,6 +20,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr.Utils
         }
 
         /// <summary>
+        /// Creates a category name for Dapr binding to be used in logging.
+        /// </summary>
+        /// <param name="bindingType">The type of the trigger.</param>
+        /// <returns>A category name for Dapr binding.</returns>
+        public static string CreateDaprBindingCategory(string bindingType)
+        {
+            return $"Host.Bindings.Dapr.{bindingType}";
+        }
+
+        /// <summary>
         /// Creates a category name for Dapr triggers to be used in logging.
         /// </summary>
         /// <returns>A category name for Dapr triggers.</returns>

--- a/test/DaprExtensionTests/UnitTests/Services/DaprHttpClientTests.cs
+++ b/test/DaprExtensionTests/UnitTests/Services/DaprHttpClientTests.cs
@@ -5,17 +5,19 @@
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.WebJobs.Extensions.Dapr.Services;
+    using Microsoft.Azure.WebJobs.Extensions.Dapr.Utils;
     using Microsoft.Extensions.Logging;
     using Moq;
     using Xunit;
 
     public class DaprHttpClientTests
     {
-        private readonly ILoggerFactory loggerFactory;
+        private readonly ILogger logger;
 
         public DaprHttpClientTests()
         {
-            this.loggerFactory = new Mock<LoggerFactory>().Object;
+            var loggerFactory = new Mock<LoggerFactory>().Object;
+            this.logger = loggerFactory.CreateLogger(LoggingUtils.CreateDaprBindingCategory());
         }
 
         [Fact]
@@ -23,12 +25,12 @@
         {
             // Arrange
             var clientFactory = new TestHttpClientFactory(new HttpResponseMessage(HttpStatusCode.OK));
-            var httpClient = new DaprHttpClient(this.loggerFactory, clientFactory);
+            var httpClient = new DaprHttpClient(clientFactory);
             var content = new StringContent("Hello World");
             var cancellationToken = CancellationToken.None;
 
             // Act
-            var response = await httpClient.PostAsync("http://localhost/api", content, cancellationToken);
+            var response = await httpClient.PostAsync(this.logger, "http://localhost/api", content, cancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -39,11 +41,11 @@
         {
             // Arrange
             var clientFactory = new TestHttpClientFactory(new HttpResponseMessage(HttpStatusCode.OK));
-            var httpClient = new DaprHttpClient(this.loggerFactory, clientFactory);
+            var httpClient = new DaprHttpClient(clientFactory);
             var cancellationToken = CancellationToken.None;
 
             // Act
-            var response = await httpClient.GetAsync("http://localhost/api", cancellationToken);
+            var response = await httpClient.GetAsync(this.logger, "http://localhost/api", cancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -54,12 +56,12 @@
         {
             // Arrange
             var clientFactory = new TestHttpClientFactory(new HttpResponseMessage(HttpStatusCode.OK));
-            var httpClient = new DaprHttpClient(this.loggerFactory, clientFactory);
+            var httpClient = new DaprHttpClient(clientFactory);
             var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://localhost/api");
             var cancellationToken = CancellationToken.None;
 
             // Act
-            var response = await httpClient.SendAsync(httpRequestMessage, cancellationToken);
+            var response = await httpClient.SendAsync(this.logger, httpRequestMessage, cancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/test/DaprExtensionTests/UnitTests/Services/DaprServiceListenerTests.cs
+++ b/test/DaprExtensionTests/UnitTests/Services/DaprServiceListenerTests.cs
@@ -47,7 +47,7 @@ namespace DaprExtensionTests.UnitTests.Services
         public async Task WarnIfSidecarMisconfigured_WhenDaprSidecarIsNotRunning()
         {
             // Arrange
-            this.daprClientMock.Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).
+            this.daprClientMock.Setup(x => x.GetAsync(It.IsAny<ILogger>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).
                 Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)));
 
             // Act
@@ -74,7 +74,7 @@ namespace DaprExtensionTests.UnitTests.Services
                 Content = new StringContent(responseBody),
             };
 
-            this.daprClientMock.Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).
+            this.daprClientMock.Setup(x => x.GetAsync(It.IsAny<ILogger>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).
                 Returns(Task.FromResult(mockResponse));
 
             // Act


### PR DESCRIPTION
This PR modifies the logging category of bindings, with this change, every input and output binding will have their own category which will help us figure the usage and make debugging easier with segregated logging categories.