### PR TITLE
Fix dotnet isolated build issue with nuget pacakage version 99.99.99

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     env:
       APP_REGISTRY: ${{ secrets.DOCKER_REGISTRY_URL }}/${{ secrets.DOCKER_REGISTRY_PATH }}
       CONFIGURATION: Release
-      DEV_VERSION_SUFFIX: 99.99.99
+      DEV_VERSION_SUFFIX: 0.0.0
       DOTNET_SAMPLE_APP_IMAGE_NAME: dotnet-azurefunction
       DOTNET_ISOLATED_QUICKSTART_APP_IMAGE_NAME: dotnet-isolated-dapr-azure-function-orderservice
       NUPKG_OUTDIR: bin/Release/nugets

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Run Unit Tests - ${{ env.CONFIGURATION }}
         run: |
           dotnet test --configuration ${{ env.CONFIGURATION }} --collect:"XPlat Code Coverage"
-      - name: Codecov
-        uses: codecov/codecov-action@v3
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: "**/coverage.cobertura.xml,./.github/codecov.yml"  # Specify the path to your Cobertura format coverage report file

--- a/docs/development/setup-ci.md
+++ b/docs/development/setup-ci.md
@@ -24,12 +24,15 @@ A GitHub account.
 | AZCOPY_SPA_CLIENT_SECRET | Service principal client secret for AzCopy, required for uploading NuGet and Maven artifacts |
 | AZCOPY_TENANT_ID | Tenant ID used by AzCopy to authenticate, required for uploading NuGet and Maven artifacts |
 | GITHUB_TOKEN | GitHub token, required for creating release |
-| CODECOV_TOKEN | Codecov token, required for uploading code coverage results |
+| CODECOV_TOKEN | [Codecov token](#generate-codecov_token), required for uploading code coverage results |
 
 Notes
 - `GITHUB_TOKEN` is automatically set by GitHub Actions, so you don't need to set it manually.
 - `AZCOPY_*` secrets should not be set for forks, as they are only required for uploading NuGet packages for official release. The step that requires these secrets will be skipped for forks.
 
 4. Go to `Settings` -> `Actions` -> `General` and make sure to allow running GitHub Actions.
+
+### Generate CODECOV_TOKEN
+To generate`CODECOV_TOKEN`, go to [this website](https://app.codecov.io/github/azure/azure-functions-dapr-extension/settings) and generate the upload token. Same should be updated in GitHub secrets for `CODECOV_TOKEN`
 
 

--- a/docs/development/setup-ci.md
+++ b/docs/development/setup-ci.md
@@ -33,6 +33,6 @@ Notes
 4. Go to `Settings` -> `Actions` -> `General` and make sure to allow running GitHub Actions.
 
 ### Generate CODECOV_TOKEN
-To generate`CODECOV_TOKEN`, go to [this website](https://app.codecov.io/github/azure/azure-functions-dapr-extension/settings) and generate the upload token. Same should be updated in GitHub secrets for `CODECOV_TOKEN`
+To generate`CODECOV_TOKEN`, go to [this website](https://app.codecov.io/github/azure/azure-functions-dapr-extension/settings) and generate the upload token. Same should be updated in GitHub secrets for `CODECOV_TOKEN`. Make sure you are part of Azure GitHub Org and are owner of `azure-functions-dapr-extension` GitHub repo.
 
 

--- a/samples/dotnet-isolated-azurefunction/dotnet-isolated-azurefunction.csproj
+++ b/samples/dotnet-isolated-azurefunction/dotnet-isolated-azurefunction.csproj
@@ -14,10 +14,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.10.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.7.0" />
-   
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Microsoft.Azure.Functions.Worker.Extensions.Dapr\Microsoft.Azure.Functions.Worker.Extensions.Dapr.csproj" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Dapr" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/samples/dotnet-isolated-azurefunction/dotnet-isolated-azurefunction.csproj
+++ b/samples/dotnet-isolated-azurefunction/dotnet-isolated-azurefunction.csproj
@@ -14,7 +14,9 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.10.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.7.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Dapr" Version="1.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Azure.Functions.Worker.Extensions.Dapr\Microsoft.Azure.Functions.Worker.Extensions.Dapr.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/samples/javascript-v4-azurefunction/src/functions/stateOutputBinding.js
+++ b/samples/javascript-v4-azurefunction/src/functions/stateOutputBinding.js
@@ -1,6 +1,6 @@
 const { app, output, trigger } = require('@azure/functions');
 
-const daprStateOuput = output.generic({
+const daprStateOutput = output.generic({
     type: "daprState",
     stateStore: "%StateStoreName%",
     direction: "out",
@@ -16,7 +16,7 @@ app.generic('StateOutputBinding', {
         route: "state/{key}",
         name: "req"
     }),
-    return: daprStateOuput,
+    return: daprStateOutput,
     handler: async (request, context) => {
         context.log("Node HTTP trigger function processed a request.");
 

--- a/src/Microsoft.Azure.Functions.Extensions.Dapr.Core/Microsoft.Azure.Functions.Extensions.Dapr.Core.csproj
+++ b/src/Microsoft.Azure.Functions.Extensions.Dapr.Core/Microsoft.Azure.Functions.Extensions.Dapr.Core.csproj
@@ -6,7 +6,7 @@
     <PackageId>Microsoft.Azure.Functions.Extensions.Dapr.Core</PackageId>
     <IsPackable>true</IsPackable>
     <!-- Default version for dev -->
-    <Version>99.99.99</Version>
+    <Version>0.0.0</Version>
     <Description>Common models and utilities for Dapr extension for Azure functions.</Description>
     <Summary>Common models and utilities for Dapr extension for Azure functions.</Summary>
   </PropertyGroup>
@@ -24,8 +24,8 @@
 
   <!-- Delete the nuget cache for the package -->
   <Target Name="RemoveNugetPackageCache" BeforeTargets="Build">
-    <RemoveDir Directories="$(NugetPackageRoot)/$(PackageId)/99.99.99"></RemoveDir>
-    <Message Text="Deleted nuget cache for $(PackageId)/99.99.99" Importance="high" />
+    <RemoveDir Directories="$(NugetPackageRoot)/$(PackageId)/0.0.0"></RemoveDir>
+    <Message Text="Deleted nuget cache for $(PackageId)/0.0.0" Importance="high" />
   </Target>
 
   <!-- Copy the nupkg to local-packages folder -->

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Dapr/Microsoft.Azure.Functions.Worker.Extensions.Dapr.csproj
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Dapr/Microsoft.Azure.Functions.Worker.Extensions.Dapr.csproj
@@ -12,8 +12,8 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <!-- Default version for dev -->
-    <Version>99.99.99</Version>
-    <SupportedVersion>99.99.99</SupportedVersion>
+    <Version>0.0.0</Version>
+    <WebJobSupportedVersion>0.0.0</WebJobSupportedVersion>
     <PackageTags>Microsoft Azure WebJobs Azure-Functions Isolated Dotnet-Isolated Dapr Worker</PackageTags>
   </PropertyGroup>
 
@@ -36,7 +36,7 @@
   <ItemGroup>
     <AssemblyAttribute Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions.ExtensionInformationAttribute">
       <_Parameter1>Microsoft.Azure.WebJobs.Extensions.Dapr</_Parameter1>
-      <_Parameter2>$(SupportedVersion)</_Parameter2>
+      <_Parameter2>$(WebJobSupportedVersion)</_Parameter2>
     </AssemblyAttribute>
   </ItemGroup>
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.Dapr/Microsoft.Azure.WebJobs.Extensions.Dapr.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Dapr/Microsoft.Azure.WebJobs.Extensions.Dapr.csproj
@@ -9,7 +9,7 @@
     <Description>Dapr extension for Azure functions using the in-process execution model.</Description>
     <Summary>Dapr extension for Azure functions using the in-process execution model.</Summary>
     <!-- Default version for dev -->
-    <Version>99.99.99</Version>
+    <Version>0.0.0</Version>
   </PropertyGroup>
 
   <!-- Use C# 9.0 features -->
@@ -41,8 +41,8 @@
 
   <!-- Delete the nuget cache for the package -->
   <Target Name="RemoveNugetPackageCache" BeforeTargets="Build">
-    <RemoveDir Directories="$(NugetPackageRoot)/$(PackageId)/99.99.99"></RemoveDir>
-    <Message Text="Deleted nuget cache for $(PackageId)/99.99.99" Importance="high" />
+    <RemoveDir Directories="$(NugetPackageRoot)/$(PackageId)/0.0.0"></RemoveDir>
+    <Message Text="Deleted nuget cache for $(PackageId)/0.0.0" Importance="high" />
   </Target>
 
   <!-- Copy the nupkg to local-packages folder -->

--- a/troubleshooting-guide.md
+++ b/troubleshooting-guide.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-Welcome to the troubleshooting guide for Azure Functions Dapr Extension. This guide is designed to help you address common issues and problems that may arise during the usage of Dapr Extension. Please follow the steps below to resolve any issues you encounter.
+Welcome to the troubleshooting guide for Azure Functions Dapr Extension. This guide is designed to help you address common issues and problems that may arise during the usage of Dapr Extension. Please follow the steps below to resolve any issues you encounter. 
 
 ## Table of Contents
 


### PR DESCRIPTION
**Problem**
Dotnet isolated Azure Function with the Dapr extension encounters a build issue due to a missing `Microsoft.Azure.WebJobs.Extensions.Dapr` package with version `99.99.99`.

**Root Cause**
When users build the repository `https://github.com/Azure/azure-functions-dapr-extension.git` locally, the Dotnet isolated worker dynamically creates a `WorkerExtensions.csproj` file. In this file, `Microsoft.Azure.WebJobs.Extensions.Dapr` is registered as a NuGet package dependency with version `99.99.99`. This version is intended as a placeholder for a local NuGet package, but the Dotnet build process mistakenly looks for it on nuget.org, where it does not exist.

**Solution**
Rebuilding the dynamically created `WorkerExtensions.csproj` does not affect the actual project. To resolve the issue, we replace the placeholder version `99.99.99` with `0.0.0`. This change ensures that when the dynamically created `WorkerExtensions.csproj` searches for version `0.0.0`, it will find the latest available NuGet package on nuget.org, thus avoiding the build error.

This PR upgrades Codecov GitHub task to V4 to fix codecov issue.